### PR TITLE
Preload crowdfunding data for overlay.

### DIFF
--- a/src/components/CampaignVisualisations/index.js
+++ b/src/components/CampaignVisualisations/index.js
@@ -62,14 +62,10 @@ export default ({ visualisations }) => {
   );
 };
 
-export const CrowdFundingVisualistation = ({ startnextId, goal, ...props }) => {
-  const [crowdFunding] = useGetCrowdfundingDirectly(startnextId);
-
-  if (!crowdFunding) {
+export const CrowdFundingVisualistation = ({ project, goal, ...props }) => {
+  if (!project) {
     return <SectionInner>lade...</SectionInner>;
   }
-
-  const project = crowdFunding.project;
 
   return (
     <Visualisation

--- a/src/components/CampaignVisualisations/index.js
+++ b/src/components/CampaignVisualisations/index.js
@@ -62,16 +62,35 @@ export default ({ visualisations }) => {
   );
 };
 
-export const CrowdFundingVisualistation = ({ project, goal, ...props }) => {
-  if (!project) {
+export const CrowdFundingVisualistation = ({ startnextId, goal, ...props }) => {
+  // Check props includes a project key
+  const hasProjectProp = 'project' in props;
+
+  // If props does not include project key, query startnext
+  const [crowdFunding] = !hasProjectProp
+    ? useGetCrowdfundingDirectly(startnextId)
+    : null;
+
+  // If data is loading
+  if (
+    // Has project property but no value
+    (hasProjectProp && props.project == null) ||
+    // Startnext query in progress in this component
+    (!hasProjectProp && !crowdFunding)
+  ) {
     return <SectionInner>lade...</SectionInner>;
   }
 
+  // Use the correct project object
+  const crowdfundingProject = hasProjectProp
+    ? props.project
+    : crowdFunding.project;
+
   return (
     <Visualisation
-      goal={project.funding_target}
-      count={Math.round(project.funding_status || 0)}
-      startDate={project.start_date}
+      goal={crowdfundingProject.funding_target}
+      count={Math.round(crowdfundingProject.funding_status || 0)}
+      startDate={crowdfundingProject.start_date}
       currency="€"
       currencyShort="€"
       showCTA={props.ctaLink}

--- a/src/components/CampaignVisualisations/index.js
+++ b/src/components/CampaignVisualisations/index.js
@@ -64,7 +64,7 @@ export default ({ visualisations }) => {
 
 export const CrowdFundingVisualistation = ({ startnextId, goal, ...props }) => {
   // Check props includes a project key
-  const hasProjectProp = 'project' in props;
+  const hasProjectProp = props.hasOwnProperty('project');
 
   // If props does not include project key, query startnext
   const [crowdFunding] = !hasProjectProp

--- a/src/components/CampaignVisualisations/index.js
+++ b/src/components/CampaignVisualisations/index.js
@@ -69,7 +69,7 @@ export const CrowdFundingVisualistation = ({ startnextId, goal, ...props }) => {
   // If props does not include project key, query startnext
   const [crowdFunding] = !hasProjectProp
     ? useGetCrowdfundingDirectly(startnextId)
-    : null;
+    : [];
 
   // If data is loading
   if (

--- a/src/components/Layout/index.js
+++ b/src/components/Layout/index.js
@@ -7,7 +7,7 @@ import Sections, { ContentfulSection } from './Sections';
 import { Helmet } from 'react-helmet-async';
 import { useStaticQuery, graphql } from 'gatsby';
 import { Overlay } from '../Overlay';
-import { useGetCrowdfundingDirectly } from '../../hooks/Api/Crowdfunding';
+import { buildVisualisationsWithCrowdfunding } from '../../hooks/Api/Crowdfunding';
 
 function Template({ children, sections }) {
   const { contentfulGlobalStuff: globalStuff } = useStaticQuery(graphql`
@@ -117,32 +117,15 @@ function Template({ children, sections }) {
     }
   `);
 
-  const visualisationsWithoutCrowdfunding = globalStuff.overlay.campainVisualisations.filter(
-    vis => !vis.startnextId
+  // Return list of visualisation definitions with project field for the startnext project data
+  const visualisationsWithCrowdfunding = buildVisualisationsWithCrowdfunding(
+    globalStuff.overlay.campainVisualisations
   );
 
-  // Get visualisations that have startnext ID
-  const startnextVisualisations = globalStuff.overlay.campainVisualisations.filter(
-    vis => vis.startnextId
-  );
-
-  // Return list of visualisation definitions with project property
-  const visualisationsWithCrowdfunding = startnextVisualisations.map(vis => {
-    const [crowdfunding] = useGetCrowdfundingDirectly(vis.startnextId);
-    const { project } = crowdfunding ? crowdfunding : {};
-
-    return {
-      ...vis,
-      project,
-    };
-  });
-
+  // Create new overlay definition
   const overlayDefninitionWithCrowdfunding = {
     ...globalStuff.overlay,
-    campainVisualisations: [
-      ...visualisationsWithCrowdfunding,
-      visualisationsWithoutCrowdfunding,
-    ],
+    campainVisualisations: visualisationsWithCrowdfunding,
   };
 
   return (

--- a/src/components/Layout/index.js
+++ b/src/components/Layout/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import Header from './Header';
 import Footer from './Footer';
 import s from './style.module.less';

--- a/src/hooks/Api/Crowdfunding/index.js
+++ b/src/hooks/Api/Crowdfunding/index.js
@@ -12,42 +12,6 @@ import CONFIG from '../../../../aws-config';
   - data
 */
 
-export const useCrowdfundingData = projectId => {
-  const [data, setData] = useState(() => {
-    if (typeof window !== 'undefined') {
-      getCrowdfundingData(projectId).then(result => setData(result));
-    }
-  });
-
-  return data;
-};
-
-// gets data of crowdfunding campaign
-const getCrowdfundingData = async projectId => {
-  try {
-    const request = {
-      method: 'GET',
-      mode: 'cors',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    };
-
-    const response = await fetch(
-      `${CONFIG.API.INVOKE_URL}/analytics/crowdfunding?projectId=${projectId}`,
-      request
-    );
-
-    if (response.status === 200) {
-      return await response.json();
-    } else {
-      console.log('Response is not 200', response.status);
-    }
-  } catch (error) {
-    console.log('Error while getting crowdfunding data', error);
-  }
-};
-
 export const useGetCrowdfundingDirectly = projectId => {
   const [crowdFunding, setCrowdFunding] = useState(() => {
     if (typeof window !== `undefined`) {
@@ -110,4 +74,26 @@ const loadScript = (source, beforeEl, async = true, defer = true) => {
       prior.parentNode.insertBefore(script, prior);
     }
   });
+};
+
+export const buildVisualisationsWithCrowdfunding = visualisations => {
+  const visualisationsWithoutCrowdfunding = visualisations.filter(
+    vis => !vis.startnextId
+  );
+  const startnextVisualisations = visualisations.filter(vis => vis.startnextId);
+
+  const visualisationsWithCrowdfunding = startnextVisualisations.map(vis => {
+    const [crowdfunding] = useGetCrowdfundingDirectly(vis.startnextId);
+    const { project } = crowdfunding ? crowdfunding : {};
+
+    return {
+      ...vis,
+      project,
+    };
+  });
+
+  return [
+    ...visualisationsWithCrowdfunding,
+    ...visualisationsWithoutCrowdfunding,
+  ];
 };

--- a/src/hooks/Api/Crowdfunding/index.js
+++ b/src/hooks/Api/Crowdfunding/index.js
@@ -82,6 +82,7 @@ export const buildVisualisationsWithCrowdfunding = visualisations => {
   );
   const startnextVisualisations = visualisations.filter(vis => vis.startnextId);
 
+  // For all visualisations with startnext key, add project property with the crowdfunding data
   const visualisationsWithCrowdfunding = startnextVisualisations.map(vis => {
     const [crowdfunding] = useGetCrowdfundingDirectly(vis.startnextId);
     const { project } = crowdfunding ? crowdfunding : {};


### PR DESCRIPTION
Resolves: https://trello.com/c/tpqKQleh

Fetches the crowdfunding data from Startnext before the overlay is loaded.

Changes:
* Adds function `buildVisualisationsWithCrowdfunding` in `hooks/Api/Crowdfunding` for returning a list of all visualisations where the visualisations with a startnext id have a new property `project`, which has the startnext project data as its value
* Extends `CrowdfundingVisualisation` to use the project data in props if the key exists, otherwise it will query the startnext api and load the project data.
* Use the `buildVisualisationsWithCrowdfunding` function in the layout to build a new overlay definition that can fetch the startnext project data before the overlay is opened.

