### PR TITLE
Show visualisation count outside text < 50%

### DIFF
--- a/src/components/CampaignVisualisations/index.js
+++ b/src/components/CampaignVisualisations/index.js
@@ -203,7 +203,7 @@ export const Visualisation = ({
     count && isInView
       ? Math.max(Math.min((count / (goalInbetween || goal)) * 100, 100), 3)
       : 0;
-  const countOutside = percentage < 40;
+  const countOutside = percentage < 50;
 
   const barGoalWidth = Math.min(100, ((goalInbetween || goal) / count) * 100);
   return (


### PR DESCRIPTION
Resolves https://trello.com/c/QHhn4TSb

I don't really love how on bigger screens now the text goes on the outside when there is plenty of room inside, but I think this solution is good for the time being.