### PR TITLE
SelfScan: Fixed display of signatures

### DIFF
--- a/src/components/CampaignVisualisations/index.js
+++ b/src/components/CampaignVisualisations/index.js
@@ -101,7 +101,6 @@ export const CampainVisualisation = ({
   minimum,
   maximum,
   addToSignatureCount,
-  addSelfScanned,
   currentCount,
   ...props
 }) => {
@@ -119,10 +118,6 @@ export const CampainVisualisation = ({
     if (maximum) {
       count = Math.min(count, maximum);
     }
-  }
-
-  if (addSelfScanned) {
-    count += addSelfScanned;
   }
 
   return <Visualisation count={count} {...props} />;

--- a/src/components/Forms/SelfScan/index.js
+++ b/src/components/Forms/SelfScan/index.js
@@ -48,7 +48,7 @@ export default ({ successMessage, campaignCode }) => {
     if (userId || eMail) {
       getSignatureCountOfUser({ userId: userId, email: eMail });
     }
-  }, [userId, eMail]);
+  }, [userId, eMail, state]);
 
   useEffect(() => {
     if (isAuthenticated && sessionUserId) {
@@ -84,17 +84,11 @@ export default ({ successMessage, campaignCode }) => {
     }
   `);
 
-  const addedSelfScanned = state === 'saved' ? count : 0;
-
   const campaignVisualisationsMapped = campaignVisualisations
     .map(({ node }) => node)
     .filter(({ campainCode: campaignCodeVisualisation }) => {
       return campaignCodeVisualisation === campaignCode;
     });
-
-  if (signatureCountOfUser && signatureCountOfUser.scannedByUser) {
-    campaignVisualisationsMapped[0].addSelfScanned = addedSelfScanned;
-  }
 
   const countSignaturesFormProps = {
     state,
@@ -119,7 +113,7 @@ export default ({ successMessage, campaignCode }) => {
             <div className={s.statisticsOverallCountItem}>
               <div className={s.statisticsOverallCount}>
                 <VisualCounter
-                  end={signatureCountOfUser.scannedByUser + addedSelfScanned}
+                  end={signatureCountOfUser.scannedByUser}
                 />
               </div>
               <div className={s.statisticsOverallLabel}>
@@ -303,7 +297,7 @@ const CountSignaturesForm = ({
       <Form
         onSubmit={data => {
           data.campaignCode = campaignCode;
-
+          
           // We can set both the list id and user id here,
           // because if the param is not set it will just be null
           data.userId = userId;
@@ -314,9 +308,14 @@ const CountSignaturesForm = ({
             data.listId = listId;
           }
 
+          // If user clicks on 'Mehr eintragen', the email cannot be read from the form.
+          // Therefore, we have to add it to the data object manually. 
           if (data.email) {
             setEMail(data.email);
+          } else if (eMail) {
+            data.email = eMail;
           }
+
           setCount(parseInt(data.count));
           updateSignatureList(data);
         }}


### PR DESCRIPTION
Fixed a bug showing a wrong number of signatures already added on the form to self report signatures.

- Changed the useEffect dependency array that calls ''getSignatureCountOfUser' to listen to a change of state (as well as UserId and eMail). That way, the amount of signatures scanned by the user displays correctly whenever the form is saved or reopened.
- Removed 'AddSelfScanned' and 'AddedSelfScanned', because they are no longer needed
- When user clicks on 'Mehr eintragen', they do not have to reenter their email address. To make sure the data is submitted correctly, the email address will now be readded to the form object before submit.