### PR TITLE
anchors to work with lowercase or uppercase

### DIFF
--- a/src/components/Layout/Sections/index.js
+++ b/src/components/Layout/Sections/index.js
@@ -192,7 +192,7 @@ export function Section({
       })}
     >
       {jumpToId && (
-        <div id={jumpToId} className={s.jumpToAnchor}>
+        <div id={jumpToId[0].toUpperCase() + jumpToId.slice(1)} className={s.jumpToAnchor}>
           <div id={jumpToId.toLowerCase()} />
         </div>
       )}


### PR DESCRIPTION
have two different ids (first letter uppercase, first letter lowercase) for the two divs, no matter what the input is
now we can set all slugs in contentful to lowercase, anchors with first letter uppercase that are out there will still work and not break.