### PR TITLE
fix blog header links on hover

### DIFF
--- a/src/components/style/base.less
+++ b/src/components/style/base.less
@@ -23,6 +23,10 @@ body {
     }
 }
 
+h1 {
+    line-height: 1.4;
+}
+
 h1, h2, h3 {
     font-size: @fontSizeL;
 

--- a/src/components/style/vars.less
+++ b/src/components/style/vars.less
@@ -101,6 +101,6 @@
 
 .linkUnderlined() {
   text-decoration: none;
-  display: inline-block;
-  box-shadow: inset 0 -0.1em currentColor;
+  box-shadow: 0 0.1em currentColor;
+  border-bottom: .05em transparent solid;
 }


### PR DESCRIPTION
Changes `.linkUnderlined()` which is also used in the header and the footer. Slightly increases line-height of `<h1 />`. To test, check those out and also other occurrences of `<h1 />`.

Before:
![Screen Shot 2020-06-11 at 14 43 46](https://user-images.githubusercontent.com/1699298/84388040-35ba6780-abf4-11ea-87bd-59f1bd518ce9.png)

After: 
![Screen Shot 2020-06-11 at 14 56 06](https://user-images.githubusercontent.com/1699298/84388055-3b17b200-abf4-11ea-8969-c88c53fd9fae.png)

Trello: https://trello.com/c/DnTexNq1/563-025-blog-überschriften-link-underline-ist-seltsam