### PR TITLE
Lowercase email before sign up and sign in

### DIFF
--- a/src/hooks/Authentication/index.js
+++ b/src/hooks/Authentication/index.js
@@ -62,7 +62,7 @@ const signUp = async (email, setState, { setUserId, setTempEmail }) => {
 
     // We have to “generate” a password for them, because a password is required by Amazon Cognito when users sign up
     const { userSub } = await Auth.signUp({
-      username: email,
+      username: email.toLowerCase(),
       password: getRandomString(30),
     });
 
@@ -147,7 +147,7 @@ const signIn = async (setState, { setCognitoUser, userId, tempEmail }) => {
 
     // This will initiate the custom flow, which will lead to the user receiving a mail.
     // The code will timeout after 3 minutes (enforced server side by AWS Cognito).
-    const user = await Auth.signIn(userId || tempEmail);
+    const user = await Auth.signIn(userId || tempEmail.toLowerCase());
 
     // We already set the user here in the global context,
     // because we need the object in answerCustomChallenge()

--- a/src/hooks/Authentication/index.js
+++ b/src/hooks/Authentication/index.js
@@ -97,7 +97,7 @@ const confirmSignUp = async (email, confirmationCode, setVerificationState) => {
     );
 
     //use auth class to confirm sing up
-    await Auth.confirmSignUp(email, confirmationCode);
+    await Auth.confirmSignUp(email.toLowerCase(), confirmationCode);
     setVerificationState('verified');
     return true;
   } catch (error) {


### PR DESCRIPTION
As part of a strategy to only work with lowercase emails from now on I adjusted the sign up and sign in hooks to set emails to lowercase before passing them to the amplify functions.

To test: 
Sign up (e.g. via general pledge, does not have to be a new user) and sign in (also e.g. general pledge) with an email with uppercase letters and check (e.g. in the network analysis) if the email parameter was lowercased.  