### PR TITLE
Check for window before querying local storage

### DIFF
--- a/src/hooks/Authentication/LocalStorageUser/index.js
+++ b/src/hooks/Authentication/LocalStorageUser/index.js
@@ -7,8 +7,12 @@ export const useLocalStorageUser = () => {
   const [userId, setUserIdState] = useState(() => {
     // Initial value comes from localStorage
     try {
-      const userId = window.localStorage.getItem(USER_ID_KEY);
-      return userId ? userId : undefined;
+      if (typeof window !== 'undefined') {
+        const userId = window.localStorage.getItem(USER_ID_KEY);
+        return userId ? userId : undefined;
+      }
+
+      return undefined;
     } catch (err) {
       console.warn('Error querying localStorage for user-id', err);
       return undefined;


### PR DESCRIPTION
Netlify logs a bunch of errors when builind because the error is caught. 
Error querying localStorage for user-id ReferenceError: window is not defined