### PR TITLE
Profile - Signature Collection Section

### DIFF
--- a/src/components/Forms/SelfScan/index.js
+++ b/src/components/Forms/SelfScan/index.js
@@ -13,10 +13,10 @@ import { SectionInner, Section } from '../../Layout/Sections';
 import querystring from 'query-string';
 import { useStaticQuery, graphql } from 'gatsby';
 import CampaignVisualisations from '../../CampaignVisualisations';
-import VisualCounter from '../../VisualCounter';
 import cN from 'classnames';
 import AuthContext from '../../../context/Authentication';
 import AuthInfo from '../../AuthInfo';
+import SignatureStats from '../../SignatureStats';
 
 export default ({ successMessage, campaignCode }) => {
   const [
@@ -103,30 +103,10 @@ export default ({ successMessage, campaignCode }) => {
     <>
       {signatureCountOfUser && state !== 'userNotFound' && state !== 'error' ? (
         <Section>
-          <div className={s.statisticsOverall}>
-            <div className={s.statisticsOverallCountItem}>
-              <div className={s.statisticsOverallCount}>
-                <VisualCounter end={signatureCountOfUser.scannedByUser} />
-              </div>
-              <div className={s.statisticsOverallLabel}>
-                Unterschriften
-                <br />
-                von dir gemeldet
-              </div>
-            </div>{' '}
-            <div className={s.statisticsOverallCountItem}>
-              <div className={s.statisticsOverallCount}>
-                <VisualCounter end={signatureCountOfUser.received} />
-              </div>
-              <div className={s.statisticsOverallLabel}>
-                Unterschriften
-                <br />
-                von dir bei uns
-                <br />
-                angekommen
-              </div>
-            </div>
-          </div>
+          <SignatureStats
+            signatureCount={signatureCountOfUser}
+            className={s.statisticsOverall}
+          />
           <div className={s.visualisation}>
             <CountSignaturesForm {...countSignaturesFormProps} />
             {campaignVisualisationsMapped.length && (

--- a/src/components/Forms/SelfScan/style.module.less
+++ b/src/components/Forms/SelfScan/style.module.less
@@ -61,23 +61,6 @@
   }
 }
 
-.statisticsOverallCount {
-  font-size: @fontSizeXXXL;
-
-  @media (max-width: @breakPointM) {
-    font-size: @fontSizeXXL;
-  }
-}
-
-.statisticsOverallLabel {
-  font-size: @fontSizeM;
-  line-height: 1.3;
-
-  @media (max-width: @breakPointM) {
-    font-size: @fontSizeS;
-  }
-}
-
 .visualisation {
   grid-column: 5 / wide-end;
 

--- a/src/components/SignatureStats/index.js
+++ b/src/components/SignatureStats/index.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import VisualCounter from '../VisualCounter';
+import s from './style.module.less';
+
+export default ({ signatureCount, layout, className }) => {
+  return (
+    <div className={className}>
+      <div className={s.statisticsCountItem}>
+        <div className={s.statisticsCount}>
+          <VisualCounter end={signatureCount.scannedByUser} />
+        </div>
+        <div className={s.statisticsLabel}>
+          Unterschriften
+          <br />
+          von dir gemeldet
+        </div>
+      </div>{' '}
+      <div className={s.statisticsCountItem}>
+        <div className={s.statisticsCount}>
+          <VisualCounter end={signatureCount.received} />
+        </div>
+        <div className={s.statisticsLabel}>
+          Unterschriften
+          {layout === 'horizontal' ? ' ' : <br />}
+          von dir bei uns
+          {layout === 'horizontal' ? ' ' : <br />}
+          angekommen
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/SignatureStats/style.module.less
+++ b/src/components/SignatureStats/style.module.less
@@ -3,6 +3,14 @@
 .statisticsCountItem {
   padding-right: 4rem;
   max-width: 20rem;
+
+  &:last-of-type {
+    margin-bottom: 0rem;
+  }
+
+  @media (max-width: @breakPointS) {
+    margin-bottom: 2rem;
+  }
 }
 
 .statisticsCount {

--- a/src/components/SignatureStats/style.module.less
+++ b/src/components/SignatureStats/style.module.less
@@ -1,0 +1,23 @@
+@import '../style/vars.less';
+
+.statisticsCountItem {
+  padding-right: 4rem;
+  max-width: 20rem;
+}
+
+.statisticsCount {
+  font-size: @fontSizeXXXL;
+
+  @media (max-width: @breakPointM) {
+    font-size: @fontSizeXXL;
+  }
+}
+
+.statisticsLabel {
+  font-size: @fontSizeM;
+  line-height: 1.3;
+
+  @media (max-width: @breakPointM) {
+    font-size: @fontSizeS;
+  }
+}

--- a/src/hooks/Api/Signatures/Get/index.js
+++ b/src/hooks/Api/Signatures/Get/index.js
@@ -31,12 +31,39 @@ export const useSignatureCountOfUser = () => {
   return [
     stats,
     data => {
-      getSignatureCountOfUser(data).then(data => setStats(data));
+      getSignatureCountOfUser(data).then(data => {
+        // get the most recent relevant campaing
+        data.mostRecentCampaign = getMostRecentCampaign(data);
+
+        setStats(data);
+      });
     },
     () => {
       setStats(null);
     },
   ];
+};
+
+// Looks though the scans of user to find out what the most recent campaign is
+const getMostRecentCampaign = data => {
+  if (data.receivedList.length > 0 && data.scannedByUserList.length > 0) {
+    // If user has scanned AND sent list we compare what happened the most recently
+    if (
+      new Date(
+        data.scannedByUserList[data.scannedByUserList.length - 1].timestamp
+      ) > new Date(data.receivedList[data.receivedList.length - 1].timestamp)
+    ) {
+      return data.scannedByUserList[data.scannedByUserList.length - 1].campaign;
+    } else {
+      return data.receivedList[data.receivedList.length - 1].campaign;
+    }
+  } else if (data.scannedByUserList > 0) {
+    return data.scannedByUserList[data.scannedByUserList.length - 1].campaign;
+  } else if (data.receivedList > 0) {
+    return data.receivedList[data.receivedList.length - 1].campaign;
+  }
+
+  return null;
 };
 
 // gets stats (count of signatures) for each campaign

--- a/src/pages/benutzer/ProfilePage/index.js
+++ b/src/pages/benutzer/ProfilePage/index.js
@@ -9,11 +9,26 @@ import { Section, SectionWrapper } from '../../../components/Layout/Sections';
 import AvatarImage from '../../../components/AvatarImage';
 
 import s from './style.module.less';
+import { useSignatureCountOfUser } from '../../../hooks/Api/Signatures/Get';
+import SignatureStats from '../../../components/SignatureStats';
+
+// We need the following mappings for the link to the self scan page
+const SELF_SCAN_SLUGS = {
+  brandenburg: 'qr/bb',
+  berlin: 'qr/b',
+  'schlewsig-holstein': 'qr/sh',
+  hamburg: 'qr/hh',
+  bremen: 'qr/hb',
+};
 
 const ProfilePage = ({ id: slugId }) => {
   const { userId, isAuthenticated, customUserData: userData } = useContext(
     AuthContext
   );
+  const [
+    signatureCountOfUser,
+    getSignatureCountOfUser,
+  ] = useSignatureCountOfUser();
 
   const [isLoading, setIsLoading] = useState(true);
 
@@ -25,6 +40,8 @@ const ProfilePage = ({ id: slugId }) => {
       // Navigate to home page
       navigate('/', { replace: true });
     } else {
+      getSignatureCountOfUser({ userId });
+
       setIsLoading(false);
     }
   }, [userId]);
@@ -57,7 +74,29 @@ const ProfilePage = ({ id: slugId }) => {
               </div>
               <div className={s.profilePageSection}>
                 <h2>Eingegangene Unterschriften</h2>
-                <p>Du hast 233 Unterschriften eingetragen.</p>
+                {signatureCountOfUser && (
+                  <>
+                    <SignatureStats
+                      signatureCount={signatureCountOfUser}
+                      className={s.signatureStats}
+                      layout="horizontal"
+                    />
+
+                    <div className={s.link}>
+                      <a
+                        href={`https://expedition-grundeinkommen.de/${
+                          signatureCountOfUser.mostRecentCampaign
+                            ? SELF_SCAN_SLUGS[
+                                signatureCountOfUser.mostRecentCampaign.state
+                              ]
+                            : 'qr/b' // if user has no recent campaign default is just berlin
+                        }?userId=${userId}`}
+                      >
+                        Hier mehr eintragen...
+                      </a>
+                    </div>
+                  </>
+                )}
               </div>
             </div>
           </Section>

--- a/src/pages/benutzer/ProfilePage/style.module.less
+++ b/src/pages/benutzer/ProfilePage/style.module.less
@@ -83,6 +83,10 @@
 .signatureStats {
   display: flex;
   justify-content: left;
+
+  @media (max-width: @breakPointS) {
+    flex-wrap: wrap;
+  }
 }
 
 .link {

--- a/src/pages/benutzer/ProfilePage/style.module.less
+++ b/src/pages/benutzer/ProfilePage/style.module.less
@@ -79,3 +79,13 @@
   line-height: 1.7rem;
   font-size: 1.5rem;
 }
+
+.signatureStats {
+  display: flex;
+  justify-content: left;
+}
+
+.link {
+  margin-top: 2rem;
+  font-size: @fontSizeXS;
+}

--- a/src/pages/benutzer/ProfilePage/style.module.less
+++ b/src/pages/benutzer/ProfilePage/style.module.less
@@ -85,7 +85,7 @@
   justify-content: left;
 
   @media (max-width: @breakPointS) {
-    flex-wrap: wrap;
+    flex-direction: column;
   }
 }
 


### PR DESCRIPTION
https://trello.com/c/YiGiLtxH/607-profile-signature-collection-section-1

I extracted the signature stats of user from the self scan component into its own component and included that component into the profile page. 

Please do not hesitate to tell me if anything about the css or whatever seems a bit off or you would have done it differently. 

There was one thing that was a bit tricky: Because we wanted to inlcude a link to the self scan page we needed to check which campaign the user was part of the most recently. I did this inside the getSignatureCountOfUser hook. This could maybe be done in the self scan page in the future so that the visualisations could be shown depending on that. This would lead to us only needing one /qr page instead of /qr/b, /qr/hh etc. Maybe even some kind of "main campaign" flag in the user database would be helpful. But it's kind of an edgy case anyway because most people are only part of one campaign anyway.