### PR TITLE
Handle loading of user signup state

### DIFF
--- a/src/components/Forms/SignatureListDownload/index.js
+++ b/src/components/Forms/SignatureListDownload/index.js
@@ -75,7 +75,7 @@ export default ({ signaturesId }) => {
     );
   }
 
-  if (state === 'creating') {
+  if (state === 'creating' || signUpState === 'loading') {
     return (
       <FinallyMessage state="progress">
         Liste wird generiert, bitte einen Moment Geduld...


### PR DESCRIPTION
When the user clicks the signature list, it was not reacting until the signup state was resolved. This shows the loading state on click, which makes the interface feel more responsive.