### PR TITLE
Profile page mvp navigation

### DIFF
--- a/src/context/Authentication/index.js
+++ b/src/context/Authentication/index.js
@@ -21,6 +21,7 @@ const AuthProvider = ({ children }) => {
   const [customUserData, setCustomUserData] = useState({});
   const [token, setToken] = useState();
   const [tempEmail, setTempEmail] = useState();
+  const [previousAction, setPreviousAction] = useState();
   const [userId, setUserId] = useLocalStorageUser();
 
   const signUserOut = async () =>
@@ -113,6 +114,8 @@ const AuthProvider = ({ children }) => {
         tempEmail,
         setTempEmail,
         customUserData,
+        previousAction,
+        setPreviousAction,
       }}
     >
       {children}

--- a/src/hooks/Authentication/index.js
+++ b/src/hooks/Authentication/index.js
@@ -129,6 +129,7 @@ export const signOut = async ({
   setIsAuthenticated,
   setToken,
   setTempEmail,
+  setPreviousAction,
 }) => {
   try {
     const { default: Auth } = await import(
@@ -151,6 +152,7 @@ export const signOut = async ({
     setToken(undefined);
     setIsAuthenticated(false);
     setTempEmail(undefined);
+    setPreviousAction('signOut');
     return;
   } catch (error) {
     console.log('Error while signing out', error);

--- a/src/hooks/Authentication/index.js
+++ b/src/hooks/Authentication/index.js
@@ -40,6 +40,16 @@ export const useSignOut = () => {
   return () => signOut(context);
 };
 
+// This hook signs the user out of amplify session,
+// while keeping the user in the identified state (keeping user id in context).
+// Same as sign out hook we only return the function.
+export const useBounceToIdentifiedState = () => {
+  //get global context
+  const context = useContext(AuthContext);
+
+  return () => bounceToIdentifiedState(context);
+};
+
 // Amplifys Auth class is used to sign up user
 const signUp = async (data, setState, { setUserId, setTempEmail }) => {
   try {
@@ -144,5 +154,28 @@ export const signOut = async ({
     return;
   } catch (error) {
     console.log('Error while signing out', error);
+  }
+};
+
+// This function signs the user out of amplify session,
+// while keeping the user in the identified state (keeping user id in context)
+const bounceToIdentifiedState = async ({
+  setCognitoUser,
+  setToken,
+  setIsAuthenticated,
+}) => {
+  try {
+    const { default: Auth } = await import(
+      /* webpackChunkName: "Amplify" */ '@aws-amplify/auth'
+    );
+
+    await Auth.signOut();
+
+    // Update user state
+    setCognitoUser(null);
+    setToken(undefined);
+    setIsAuthenticated(false);
+  } catch (error) {
+    console.log('Error while bouncing user to identified state', error);
   }
 };

--- a/src/pages/mensch/ProfilePage/index.js
+++ b/src/pages/mensch/ProfilePage/index.js
@@ -128,12 +128,25 @@ const ProfilePage = ({ id: slugId }) => {
           <Section>
             <SectionInner>
               <FinallyMessage>
-                <p>
-                  Du bist mit der E-Mail-Adresse {userData.email} eingeloggt und
-                  versuchst eine andere Profilseite aufzurufen.
-                </p>
-                <LinkButtonLocal to={`/login/?nextPage=mensch%2F${userId}`}>
-                  Zu meinem Profil{' '}
+                {userId && (
+                  <p>
+                    Du bist mit der E-Mail-Adresse {userData.email} eingeloggt
+                    und versuchst eine andere Profilseite aufzurufen.
+                  </p>
+                )}
+
+                {!userId && (
+                  <p>
+                    Du versuchst auf ein Profil zuzugreifen. Dafür musst dich
+                    zuerst einloggen.
+                  </p>
+                )}
+
+                {/* If user id is undefined we don't want to redirect the next page to be the profile */}
+                <LinkButtonLocal
+                  to={userId ? `/login/?nextPage=mensch%2F${userId}` : '/login'}
+                >
+                  {userId ? 'Zu meinem Profil' : 'Zum Login'}
                 </LinkButtonLocal>
               </FinallyMessage>
             </SectionInner>

--- a/src/pages/mensch/ProfilePage/index.js
+++ b/src/pages/mensch/ProfilePage/index.js
@@ -41,23 +41,18 @@ const ProfilePage = ({ id: slugId }) => {
 
   // Get user data on page load and handle redirects
   useEffect(() => {
-    console.log('gets called', { isAuthenticated }, { userId }, { slugId });
     // If user isn't authenticated
     if (isAuthenticated === false) {
-      // Navigate to home page
-      // navigate('/', { replace: true });
-    } else if (isAuthenticated && userId !== slugId) {
-      console.log('about to bounce');
-      // We want to tell the user that they are trying to view the page
-      // of a different user. Furthermore we want to bounce the user back
-      // to the identified state.
-      bounceToIdentifiedState();
-
       setIsLoading(false);
-    } else if (isAuthenticated === false && userId === slugId) {
-      setIsLoading(false);
-    } else {
-      getSignatureCountOfUser({ userId });
+    } else if (isAuthenticated) {
+      if (userId !== slugId) {
+        // We want to tell the user that they are trying to view the page
+        // of a different user. Furthermore we want to bounce the user back
+        // to the identified state.
+        bounceToIdentifiedState();
+      } else {
+        getSignatureCountOfUser({ userId });
+      }
 
       setIsLoading(false);
     }
@@ -129,7 +124,7 @@ const ProfilePage = ({ id: slugId }) => {
         )}
 
         {/* If not authenticated and trying to access different profile show option to go to own user page */}
-        {!isLoading && !isAuthenticated && slugId !== userId && (
+        {!isLoading && slugId !== userId && (
           <Section>
             <SectionInner>
               <FinallyMessage>

--- a/src/pages/mensch/ProfilePage/index.js
+++ b/src/pages/mensch/ProfilePage/index.js
@@ -16,6 +16,7 @@ import { formatDate } from '../../../components/utils';
 import { useBounceToIdentifiedState } from '../../../hooks/Authentication';
 import { LinkButtonLocal } from '../../../components/Forms/Button';
 import { FinallyMessage } from '../../../components/Forms/FinallyMessage';
+import { EnterLoginCode } from '../../../components/Login/EnterLoginCode';
 
 // We need the following mappings for the link to the self scan page
 const SELF_SCAN_SLUGS = {
@@ -38,7 +39,7 @@ const ProfilePage = ({ id: slugId }) => {
 
   const [isLoading, setIsLoading] = useState(true);
 
-  // Get user data on page load
+  // Get user data on page load and handle redirects
   useEffect(() => {
     console.log('gets called', { isAuthenticated }, { userId }, { slugId });
     // If user isn't authenticated
@@ -52,6 +53,8 @@ const ProfilePage = ({ id: slugId }) => {
       // to the identified state.
       bounceToIdentifiedState();
 
+      setIsLoading(false);
+    } else if (isAuthenticated === false && userId === slugId) {
       setIsLoading(false);
     } else {
       getSignatureCountOfUser({ userId });
@@ -125,8 +128,8 @@ const ProfilePage = ({ id: slugId }) => {
           </Section>
         )}
 
-        {/* If not authenticated show option to go to own user page */}
-        {!isLoading && !isAuthenticated && (
+        {/* If not authenticated and trying to access different profile show option to go to own user page */}
+        {!isLoading && !isAuthenticated && slugId !== userId && (
           <Section>
             <SectionInner>
               <FinallyMessage>
@@ -138,6 +141,22 @@ const ProfilePage = ({ id: slugId }) => {
                   Zu meinem Profil{' '}
                 </LinkButtonLocal>
               </FinallyMessage>
+            </SectionInner>
+          </Section>
+        )}
+
+        {/* If not authenticated show login code */}
+        {!isLoading && !isAuthenticated && slugId === userId && (
+          <Section>
+            <SectionInner>
+              <EnterLoginCode>
+                <p>
+                  {' '}
+                  Du bist mit der E-Mail-Adresse {userData.email} eingeloggt. Um
+                  dich zu identifizieren, haben wir dir einen Code per E-Mail
+                  geschickt. Bitte gib diesen ein, um dein Profil zu sehen:
+                </p>
+              </EnterLoginCode>
             </SectionInner>
           </Section>
         )}

--- a/src/pages/mensch/ProfilePage/index.js
+++ b/src/pages/mensch/ProfilePage/index.js
@@ -1,5 +1,6 @@
 import React, { useState, useContext, useEffect } from 'react';
 import cN from 'classnames';
+import { navigate } from '@reach/router';
 import AuthContext from '../../../context/Authentication';
 import Layout from '../../../components/Layout';
 import {
@@ -28,13 +29,19 @@ const SELF_SCAN_SLUGS = {
 };
 
 const ProfilePage = ({ id: slugId }) => {
-  const { userId, isAuthenticated, customUserData: userData } = useContext(
-    AuthContext
-  );
+  const {
+    userId,
+    isAuthenticated,
+    customUserData: userData,
+    previousAction,
+    setPreviousAction,
+  } = useContext(AuthContext);
+
   const [
     signatureCountOfUser,
     getSignatureCountOfUser,
   ] = useSignatureCountOfUser();
+
   const bounceToIdentifiedState = useBounceToIdentifiedState();
 
   const [isLoading, setIsLoading] = useState(true);
@@ -57,6 +64,14 @@ const ProfilePage = ({ id: slugId }) => {
       setIsLoading(false);
     }
   }, [userId, isAuthenticated]);
+
+  // If the user signed out (e.g. through the menu, we want to navigate to homepage)
+  useEffect(() => {
+    if (previousAction === 'signOut') {
+      setPreviousAction(undefined);
+      navigate('/');
+    }
+  }, previousAction);
 
   return (
     <Layout>


### PR DESCRIPTION
To test: navigation when opening profile as following.

Authenticated and different id:
- Inform user they are logged in as user, and trying to access user page that isn’t their own.
- Bounce back to identified state
- Option to go to own user page
- This requires secret code entry

Identified and own id:
- Inform user they are logged in as user, and that they just need to confirm their identity
- show secret code entry

Identified and different id:
- Inform user they are logged in as user, and trying to access user page that isn’t their own.
- Option to go to own user page
- This requires secret code entry

Unidentified:
- Inform user they are trying to access an user page. 
- Ask if they want to login. 
- Send to login page
