### PR TITLE
Redirect to former page after login

### DIFF
--- a/src/components/Layout/Header/Menu/LoginMenuItem.jsx
+++ b/src/components/Layout/Header/Menu/LoginMenuItem.jsx
@@ -1,4 +1,5 @@
 import React, { useContext } from 'react';
+import { useLocation } from '@reach/router';
 
 import AuthContext from '../../../../context/Authentication';
 import { useSignOut } from '../../../../hooks/Authentication';
@@ -29,9 +30,16 @@ const LoginMenuItem = () => {
     AuthContext
   );
   const signOut = useSignOut();
+  const location = useLocation();
 
-  // If user is not identified, show "login" button
-  if (!userId) return <MenuItemLink slug={'login'}>Einloggen</MenuItemLink>;
+  // If user is not identified, show "login" button`, next page after login
+  // should be the current page
+  if (!userId)
+    return (
+      <MenuItemLink slug={`login/?nextPage=${location.pathname.slice(1, -1)}`}>
+        Einloggen
+      </MenuItemLink>
+    );
 
   // Where to send user when clicking "to profile" link
   const toProfileLinkLocation = isAuthenticated

--- a/src/components/Layout/Header/Menu/LoginMenuItem.jsx
+++ b/src/components/Layout/Header/Menu/LoginMenuItem.jsx
@@ -36,7 +36,13 @@ const LoginMenuItem = () => {
   // should be the current page
   if (!userId)
     return (
-      <MenuItemLink slug={`login/?nextPage=${location.pathname.slice(1, -1)}`}>
+      <MenuItemLink
+        slug={`login${
+          location.pathname !== '/'
+            ? `/?nextPage=${location.pathname.slice(1, -1)}`
+            : ''
+        }`}
+      >
         Einloggen
       </MenuItemLink>
     );

--- a/src/pages/login/index.js
+++ b/src/pages/login/index.js
@@ -1,5 +1,5 @@
 import Layout from '../../components/Layout';
-import React, { useContext, useEffect } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import querystring from 'query-string';
 import { navigate } from '@reach/router';
 
@@ -14,6 +14,7 @@ import { RequestLoginCodeWithEmail } from '../../components/Login/RequestLoginCo
 
 const LoginPage = () => {
   const { isAuthenticated, setTempEmail } = useContext(AuthContext);
+  const [urlParams, setUrlParams] = useState();
 
   // Remove tempEmail when user navigates away
   useEffect(() => {
@@ -23,12 +24,16 @@ const LoginPage = () => {
   }, []);
 
   // Get next page from query params
-  const urlParams =
-    // Check for window to make sure that build works
-    typeof window !== `undefined`
-      ? // If window, parse params
-        querystring.parse(window.location.search)
-      : undefined;
+  useEffect(() => {
+    const params =
+      // Check for window to make sure that build works
+      typeof window !== `undefined`
+        ? // If window, parse params
+          querystring.parse(window.location.search)
+        : undefined;
+
+    setUrlParams(params);
+  }, []);
 
   // If user is authenticated, navigate to home page or the specified next page
   if (isAuthenticated === true)


### PR DESCRIPTION
We pass the nextPage url param to the login page, so the user gets redirected to the page they were on before. 
In the login page component I put the parsing of query params into a use effect hook, since it was a bit inefficient before and led to issues with the /#code navigation. 