### PR TITLE
Remove the request signature lists by mail option

### DIFF
--- a/src/components/Forms/SignatureListDownload/index.js
+++ b/src/components/Forms/SignatureListDownload/index.js
@@ -16,13 +16,13 @@ import DownloadListsNextSteps from '../DownloadListsNextSteps';
 
 const trackingCategory = 'ListDownload';
 
-export default ({ signaturesId }) => {
+export default ({ signaturesId, disableRequestListsByMail }) => {
   const [state, pdf, anonymous, createPdf] = useCreateSignatureList();
   const [signUpState, signUp] = useSignUp();
   const [email, setEmail] = useState();
   const [loginCodeRequested, setLoginCodeRequested] = useState();
   const { isAuthenticated, userId } = useContext(AuthContext);
-  const isBerlin = signaturesId === 'berlin-1';
+  const isDisabledRequestListsByMail = !!disableRequestListsByMail;
   const iconMail = require('./mail_red.svg');
   const iconIncognito = require('./incognito_red.svg');
 
@@ -224,7 +224,7 @@ export default ({ signaturesId }) => {
                 </>
               )}
 
-              {!isBerlin && (
+              {!isDisabledRequestListsByMail && (
                 <>
                   <div className={s.iconParagraph}>
                     <img

--- a/src/components/Layout/Sections/index.js
+++ b/src/components/Layout/Sections/index.js
@@ -55,6 +55,7 @@ export function ContentfulSection({ section }) {
     bodyTextSizeHuge,
     pledgeId,
     signaturesId,
+    disableRequestListsByMail,
     callToActionReference,
     twitterFeed,
     maps,
@@ -117,6 +118,7 @@ export function ContentfulSection({ section }) {
           {signaturesId && (
             <SignatureListDownload
               signaturesId={signaturesId}
+              disableRequestListsByMail={disableRequestListsByMail}
               className={s.pledge}
             />
           )}

--- a/src/components/Layout/index.js
+++ b/src/components/Layout/index.js
@@ -85,6 +85,7 @@ function Template({ children, sections }) {
               emailSignup
               pledgeId
               signaturesId
+              disableRequestListsByMail
               callToActionReference {
                 slug
                 title

--- a/src/components/StaticPage/index.js
+++ b/src/components/StaticPage/index.js
@@ -79,6 +79,7 @@ export const pageQuery = graphql`
             emailSignup
             pledgeId
             signaturesId
+            disableRequestListsByMail
             callToActionReference {
               slug
               title


### PR DESCRIPTION
Prerequisite: Implemented a contentful checkbox to select if users can request signature lists by mail or not.

This PR **defaults to show** the user the option to request lists by mail. Unchecked radio boxes also show the option. 
**Only actively choosing "No" in contentful removes the option.** 

![screenshot 2020-10-16 at 12 15 55](https://user-images.githubusercontent.com/32803817/96247725-ce9a2e80-0faa-11eb-8b65-47ed17ff06fa.jpg)
