### PR TITLE
Passwordless auth

### DIFF
--- a/src/components/CampaignVisualisations/index.js
+++ b/src/components/CampaignVisualisations/index.js
@@ -147,6 +147,7 @@ export const Visualisation = ({
   showCTA,
   ctaLink,
   eyeCatcher,
+  eyeCatcherLink,
   goalUnbuffered,
   index,
   hint,
@@ -218,6 +219,9 @@ export const Visualisation = ({
   const goalHasBeenReached = percentage >= 100;
 
   const barGoalWidth = Math.min(100, ((goalInbetween || goal) / count) * 100);
+
+  const eyeCatcherLinkToDisplay = eyeCatcherLink ? eyeCatcherLink : (showCTA && ctaLink);
+
   return (
     <SectionInner
       wide={true}
@@ -315,7 +319,7 @@ export const Visualisation = ({
               [s.eyeCatcherWithCta]: showCTA && ctaLink,
             })}
           >
-            <WrapInLink link={showCTA && ctaLink} className={s.eyeCatcherLink}>
+            <WrapInLink link={eyeCatcherLinkToDisplay} className={s.eyeCatcherLink}>
               <div
                 className={s.eyeCatcherBackground}
                 dangerouslySetInnerHTML={{ __html: eyeCatcherBackground }}

--- a/src/components/Forms/Pledge/index.js
+++ b/src/components/Forms/Pledge/index.js
@@ -57,7 +57,7 @@ const SignaturePledge = ({ pledgeId }) => {
   }, [isAuthenticated, hasSubmitted, userExists]);
 
   if (signUpState === 'success' && !isAuthenticated) {
-    return <EnterLoginCode />;
+    return <EnterLoginCode preventSignIn={true} />;
   }
 
   if (signUpState || createPledgeState || updatePledgeState) {

--- a/src/components/Forms/SignUp/index.js
+++ b/src/components/Forms/SignUp/index.js
@@ -18,19 +18,19 @@ export default ({
   postSignupAction,
   illustration = 'POINT_LEFT',
 }) => {
-  const [signUpState, signUp, setSignupState] = useSignUp();
+  const [signUpState, userExists, signUp, setSignUpState] = useSignUp();
   const [, updateUser] = useUpdateUser();
   const [hasSubmitted, setHasSubmitted] = useState(false);
   const { isAuthenticated, userId } = useContext(AuthContext);
 
   // After signup process is successful, do post signup
   useEffect(() => {
-    if (signUpState === 'success' && userId) {
+    if (hasSubmitted && isAuthenticated && userId) {
       if (postSignupAction) {
         postSignupAction();
       }
     }
-  }, [signUpState, userId]);
+  }, [hasSubmitted, isAuthenticated, userId]);
 
   useEffect(() => {
     // If user signs in from form
@@ -38,26 +38,28 @@ export default ({
       updateUser({
         updatedOnXbge: true,
       });
-      setSignupState('signedIn');
+      setSignUpState('signedIn');
     }
     // If user signs out after signing in
     if (!isAuthenticated && signUpState === 'signedIn') {
-      setSignupState(undefined);
+      setSignUpState(undefined);
     }
   }, [isAuthenticated, hasSubmitted]);
 
-  if (signUpState && signUpState !== 'userExists') {
+  if (signUpState === 'success') {
+    return <EnterLoginCode />;
+  }
+
+  if (signUpState) {
     return (
       <SignUpFeedbackMessage
-        state={signUpState}
+        state={
+          signUpState === 'signedIn' && !userExists ? 'success' : signUpState
+        }
         trackingId={'sign-up'}
         trackingCategory="SignUp"
       />
     );
-  }
-
-  if (signUpState === 'userExists') {
-    return <EnterLoginCode />;
   }
 
   if (isAuthenticated || userId) {

--- a/src/components/Forms/SignUp/index.js
+++ b/src/components/Forms/SignUp/index.js
@@ -47,7 +47,7 @@ export default ({
   }, [isAuthenticated, hasSubmitted]);
 
   if (signUpState === 'success') {
-    return <EnterLoginCode />;
+    return <EnterLoginCode preventSignIn={true} />;
   }
 
   if (signUpState) {

--- a/src/components/Forms/SignUpFeedbackMessage/index.js
+++ b/src/components/Forms/SignUpFeedbackMessage/index.js
@@ -27,16 +27,10 @@ export default ({ className, state, trackingId, trackingCategory }) => {
     <div className={className}>
       <FinallyMessage state={finallyState}>
         {finallyState === 'progress' && 'Wird abgeschickt...'}
+
         {(state === 'saved' || state === 'success') && (
           <>
-            Yay, danke! Bitte geh in dein E-Mail-Postfach und bestätige, dass
-            wir deine Daten speichern dürfen. Falls du unsere E-Mail nicht
-            findest, sieh bitte auch in deinem Spam-Ordner nach!
-          </>
-        )}
-        {state === 'updated' && (
-          <>
-            Yay, danke! Deine Informationen wurden ergänzt.
+            Yay, danke für deine Anmeldung!
             <br />
             <br />
             Wir sind gemeinnützig und auf Spenden angewiesen. Bitte unterstütze
@@ -44,20 +38,6 @@ export default ({ className, state, trackingId, trackingCategory }) => {
             <br />
             <br />
             <LinkButton href="/spenden">Jetzt spenden</LinkButton>
-          </>
-        )}
-        {state === 'userExists' && (
-          <>
-            Danke! Diese E-Mail-Adresse kennen wir schon - Hast du unsere
-            Antwort-Mail bekommen? Dann fehlt nur noch der letzte Klick zum
-            Bestätigen. <br />
-            <br />
-            Nichts gefunden? Dann schau doch bitte noch einmal in deinen
-            Spam-Ordner, oder schreibe uns an{' '}
-            <a href="mailto:support@expedition-grundeinkommen.de">
-              support@expedition-grundeinkommen.de
-            </a>
-            .
           </>
         )}
         {state === 'signedIn' && (

--- a/src/components/Forms/SignatureListDownload/index.js
+++ b/src/components/Forms/SignatureListDownload/index.js
@@ -18,8 +18,7 @@ const trackingCategory = 'ListDownload';
 
 export default ({ signaturesId, disableRequestListsByMail }) => {
   const [state, pdf, anonymous, createPdf] = useCreateSignatureList();
-  const [signUpState, signUp] = useSignUp();
-  const [email, setEmail] = useState();
+  const [signUpState, userExists, signUp] = useSignUp();
   const [loginCodeRequested, setLoginCodeRequested] = useState();
   const { isAuthenticated, userId } = useContext(AuthContext);
   const isDisabledRequestListsByMail = !!disableRequestListsByMail;
@@ -27,24 +26,11 @@ export default ({ signaturesId, disableRequestListsByMail }) => {
   const iconIncognito = require('./incognito_red.svg');
 
   useEffect(() => {
-    // If user was registered proceed by creating list
-    if (signUpState === 'success') {
-      createPdf({ email, campaignCode: signaturesId });
-    } else if (signUpState === 'userExists') {
-      createPdf({
-        email,
-        campaignCode: signaturesId,
-        userExists: true,
-      });
-    }
-  }, [signUpState]);
-
-  useEffect(() => {
     // Create pdf if user has authenticated after requesting their login code.
     if (isAuthenticated && typeof loginCodeRequested !== 'undefined') {
       createPdf({
         campaignCode: signaturesId,
-        userExists: true,
+        userExists,
         // We only want to update the user's newsletter consent,
         // if they did not come from identified stage (loginCodeRequested = false)
         shouldNotUpdateUser: loginCodeRequested,
@@ -52,16 +38,18 @@ export default ({ signaturesId, disableRequestListsByMail }) => {
     }
   }, [isAuthenticated, loginCodeRequested]);
 
-  // If user is not authorised after entering email, or if they are identified and request the list
+  // After user starts sign in process or if they are identified and request the list,
+  // show EnterLoginCode component
   if (
-    state === 'unauthorized' ||
-    (loginCodeRequested && !isAuthenticated && !anonymous)
+    (signUpState === 'success' || loginCodeRequested) &&
+    !isAuthenticated &&
+    !anonymous
   ) {
     return (
       <EnterLoginCode>
         <p>
-          Hey, wir kennen dich schon! Bitte gib den Code ein, den wir dir gerade
-          in einer E-Mail geschickt haben. Alternativ kannst du auch eine Liste{' '}
+          Zur Verifizierung gib bitte den Code ein, den wir dir gerade in einer
+          E-Mail geschickt haben. Alternativ kannst du auch eine Liste{' '}
           <InlineButton
             onClick={() => {
               createPdf({ campaignCode: signaturesId, anonymous: true });
@@ -123,11 +111,6 @@ export default ({ signaturesId, disableRequestListsByMail }) => {
           </p>
         )}
         <DownloadListsNextSteps>
-          {!anonymous && signUpState !== 'userExists' && (
-            <StepListItem icon="mail">
-              Check deine Mails und klick den Link, damit du dabei bist.
-            </StepListItem>
-          )}
           {anonymous && (
             <StepListItem icon="download">
               <LinkButton target="_blank" href={pdf.url}>
@@ -163,7 +146,6 @@ export default ({ signaturesId, disableRequestListsByMail }) => {
           }
 
           // If user is not identified
-          setEmail(e.email);
           signUp({ newsletterConsent: true, ...e });
         }}
         validate={values => validate(values, userId)}

--- a/src/components/Forms/SignatureListDownload/index.js
+++ b/src/components/Forms/SignatureListDownload/index.js
@@ -46,7 +46,7 @@ export default ({ signaturesId, disableRequestListsByMail }) => {
     !anonymous
   ) {
     return (
-      <EnterLoginCode>
+      <EnterLoginCode preventSignIn={signUpState === 'success'}>
         <p>
           Zur Verifizierung gib bitte den Code ein, den wir dir gerade in einer
           E-Mail geschickt haben. Alternativ kannst du auch eine Liste{' '}

--- a/src/components/Login/EnterLoginCode/index.js
+++ b/src/components/Login/EnterLoginCode/index.js
@@ -13,8 +13,8 @@ import { InlineButton } from '../../Forms/Button';
 import { CTAButtonContainer, CTAButton } from '../../Layout/CTAButton';
 import s from './style.module.less';
 
-export const EnterLoginCode = ({ children }) => {
-  const { tempEmail, setTempEmail, isAuthenticated } = useContext(AuthContext);
+export const EnterLoginCode = ({ children, preventSignIn }) => {
+  const { tempEmail, setTempEmail } = useContext(AuthContext);
   const [
     answerChallengeState,
     setCode,
@@ -23,7 +23,9 @@ export const EnterLoginCode = ({ children }) => {
   const [signInState, startSignIn] = useSignIn();
 
   useEffect(() => {
-    if (!isAuthenticated) {
+    // We don't want to start sign in again, if flag is set
+    // (we might already have started sign in outside of component)
+    if (!preventSignIn) {
       startSignIn();
     }
   }, []);

--- a/src/components/Login/EnterLoginCode/index.js
+++ b/src/components/Login/EnterLoginCode/index.js
@@ -14,7 +14,7 @@ import { CTAButtonContainer, CTAButton } from '../../Layout/CTAButton';
 import s from './style.module.less';
 
 export const EnterLoginCode = ({ children }) => {
-  const { tempEmail, setTempEmail } = useContext(AuthContext);
+  const { tempEmail, setTempEmail, isAuthenticated } = useContext(AuthContext);
   const [
     answerChallengeState,
     setCode,
@@ -23,7 +23,9 @@ export const EnterLoginCode = ({ children }) => {
   const [signInState, startSignIn] = useSignIn();
 
   useEffect(() => {
-    startSignIn();
+    if (!isAuthenticated) {
+      startSignIn();
+    }
   }, []);
 
   if (answerChallengeState === 'loading' || signInState === 'loading') {

--- a/src/components/Maps/LazyMap.js
+++ b/src/components/Maps/LazyMap.js
@@ -21,6 +21,37 @@ const DEFAULT_BOUNDS = [
   [17.030017, 55.437655],
 ];
 
+/**
+ * The `config` JSON field on a Contentful Map takes values that will be directly
+ * passed in to the mapboxgl map constructor. This function extends the default mapbox config
+ * only adding or overriding any properties that have a value on Contentful.
+ *
+ * @param {{}} defaultConfig Default mapbox config to add props to
+ * @param {{key: string; value: any}[]} props Props that get added to or override default config
+ */
+const addPropsToMapboxConfig = (defaultConfig, props) => {
+  if (!props) return defaultConfig;
+
+  // Loop through each key of each prop
+  const configWithoutNulls = Object.keys(props).reduce((acc, key) => {
+    // If value, add to accumulator
+    if (props[key]) {
+      return {
+        ...acc,
+        [key]: props[key],
+      };
+    }
+    // Otherwise, return accumulator
+    return acc;
+  }, {});
+
+  // Merge Contentful properties with the default
+  return {
+    ...defaultConfig,
+    ...configWithoutNulls,
+  };
+};
+
 export default ({ mapConfig }) => {
   const {
     allContentfulSammelort: { edges: collectSignaturesLocations },
@@ -73,11 +104,22 @@ export default ({ mapConfig }) => {
           return location.state === mapConfig.state;
         });
 
-      map = new mapboxgl.Map({
+      // Default config for mapboxgl
+      const mapboxConfigDefault = {
         container: container.current,
         style: 'mapbox://styles/mapbox/streets-v9',
-        maxBounds: mapConfig.config?.bounds || DEFAULT_BOUNDS,
-      }).addControl(new mapboxgl.NavigationControl(), 'top-left');
+        maxBounds: DEFAULT_BOUNDS,
+      };
+
+      const mapboxConfig = addPropsToMapboxConfig(
+        mapboxConfigDefault,
+        mapConfig.config
+      );
+
+      map = new mapboxgl.Map(mapboxConfig).addControl(
+        new mapboxgl.NavigationControl(),
+        'top-left'
+      );
 
       collectSignaturesLocationsFiltered.forEach(({ node: location }) => {
         if (location.location) {

--- a/src/components/StaticPage/index.js
+++ b/src/components/StaticPage/index.js
@@ -71,6 +71,8 @@ export const pageQuery = graphql`
               state
               config {
                 bounds
+                zoom
+                center
               }
             }
             callToActionLink

--- a/src/components/StaticPage/index.js
+++ b/src/components/StaticPage/index.js
@@ -55,6 +55,7 @@ export const pageQuery = graphql`
               eyeCatcher {
                 json
               }
+              eyeCatcherLink
               goalUnbuffered
               goalInbetweenMultiple
               startnextId

--- a/src/components/StaticPage/index.js
+++ b/src/components/StaticPage/index.js
@@ -70,7 +70,7 @@ export const pageQuery = graphql`
               name
               state
               config {
-                bounds
+                maxBounds
                 zoom
                 center
               }

--- a/src/hooks/Api/Signatures/Create/index.js
+++ b/src/hooks/Api/Signatures/Create/index.js
@@ -29,7 +29,7 @@ export const useCreateSignatureList = () => {
     anonymous,
     data => {
       // If non-anonymous download
-      if (!data.anonymous && (userId || data.email)) {
+      if (!data.anonymous && userId) {
         data.token = token;
         data.userId = userId;
 
@@ -66,7 +66,7 @@ const createSignatureListAnonymous = async (
 };
 
 // Function to create (or get) a signature list
-// userId or email is passed
+// userId is passed
 const createSignatureList = async (
   { userId, email, campaignCode, userExists, token, shouldNotUpdateUser },
   setState,
@@ -85,12 +85,7 @@ const createSignatureList = async (
     }
 
     //call function to make api request, returns signature list if successful (throws error otherwise)
-    const signatureList = await makeApiCall(
-      data,
-      shouldNotUpdateUser,
-      userId,
-      token
-    );
+    const signatureList = await makeApiCall(data, userId, token);
 
     setState('created');
     setPdf(signatureList);
@@ -106,11 +101,11 @@ const createSignatureList = async (
 
 // Function which calls our api to create a (new) signature list
 // Depending on whether or not the user already was authenticated,
-// we use a different endpoint, because the /signatures endpoint returns 401,
-// if user does not have newsletter consent
+// we use a different endpoint: /signatures for anonymous lists, and
+// /users/{userId}/signatures for personalized lists
 
 // Returns the list {id, url} or null
-const makeApiCall = async (data, shouldNotUpdateUser, userId, token) => {
+const makeApiCall = async (data, userId, token) => {
   // Make api call to create new singature list and get pdf
   const request = {
     method: 'POST',
@@ -122,9 +117,7 @@ const makeApiCall = async (data, shouldNotUpdateUser, userId, token) => {
     body: JSON.stringify(data),
   };
 
-  const endpoint = shouldNotUpdateUser
-    ? `/users/${userId}/signatures`
-    : '/signatures';
+  const endpoint = userId ? `/users/${userId}/signatures` : '/signatures';
 
   const response = await fetch(`${CONFIG.API.INVOKE_URL}${endpoint}`, request);
   const json = await response.json();

--- a/src/hooks/Api/Signatures/Create/index.js
+++ b/src/hooks/Api/Signatures/Create/index.js
@@ -100,8 +100,7 @@ const createSignatureList = async (
 };
 
 // Function which calls our api to create a (new) signature list
-// Depending on whether or not the user already was authenticated,
-// we use a different endpoint: /signatures for anonymous lists, and
+// We use different endpoints: /signatures for anonymous lists, and
 // /users/{userId}/signatures for personalized lists
 
 // Returns the list {id, url} or null

--- a/src/hooks/Authentication/AnswerChallenge/index.js
+++ b/src/hooks/Authentication/AnswerChallenge/index.js
@@ -50,7 +50,8 @@ const answerCustomChallenge = async (
       // offer enough flexibility
       confirmSignUp(
         tempUser.attributes.sub,
-        tempUser.signInUserSession.idToken.jwtToken
+        tempUser.signInUserSession.idToken.jwtToken,
+        answer
       );
     } catch (error) {
       setState('wrongCode');
@@ -66,9 +67,10 @@ const answerCustomChallenge = async (
 };
 
 // We use updateUser function to confirm user in dynamo db
-const confirmSignUp = async (userId, token) => {
+// Code needs to be saved in the db as well for legal reasons
+const confirmSignUp = async (userId, token, code) => {
   try {
-    await updateUser({ userId, token, confirmed: true });
+    await updateUser({ userId, token, confirmed: true, code });
   } catch (error) {
     console.log('Error while confirming user', error);
   }

--- a/src/hooks/Authentication/AnswerChallenge/index.js
+++ b/src/hooks/Authentication/AnswerChallenge/index.js
@@ -42,6 +42,10 @@ const answerCustomChallenge = async (
       //use context to set user in global state
       setCognitoUser(tempUser);
       setIsAuthenticated(true);
+
+      // We also want to set that the user is confirmed now
+      // if e.g. it was the first login (= double opt in)
+      Auth.updateUserAttributes(tempUser, { 'custom:confirmed': 'true' });
     } catch (error) {
       setState('wrongCode');
       console.log('Apparently the user did not enter the right code', error);

--- a/src/hooks/Authentication/index.js
+++ b/src/hooks/Authentication/index.js
@@ -122,9 +122,6 @@ const signUp = async (data, { setUserId }) => {
   const { userSub: userId } = await Auth.signUp({
     username: data.email.toLowerCase(),
     password: getRandomString(30),
-    attributes: {
-      'custom:confirmed': 'false', // booleans not possible
-    },
   });
 
   data.referral = getReferral();

--- a/src/hooks/Authentication/index.js
+++ b/src/hooks/Authentication/index.js
@@ -13,22 +13,13 @@ export { useAnswerChallenge } from './AnswerChallenge';
 export { useVerification } from './Verification';
 export { useLocalStorageUser } from './LocalStorageUser';
 
-export const useSignUp = () => {
-  const [state, setState] = useState();
-
-  //get global context
-  const context = useContext(AuthContext);
-
-  return [state, data => signUp(data, setState, context), setState];
-};
-
 export const useSignIn = () => {
   const [state, setState] = useState({});
 
   //get global context
   const context = useContext(AuthContext);
 
-  return [state, () => signIn(setState, context)];
+  return [state, data => startSignInProcess(data, setState, context)];
 };
 
 // hook for signing out
@@ -50,35 +41,27 @@ export const useBounceToIdentifiedState = () => {
   return () => bounceToIdentifiedState(context);
 };
 
-// Amplifys Auth class is used to sign up user
-const signUp = async (data, setState, { setUserId, setTempEmail }) => {
+const startSignInProcess = async (data, setState, context) => {
   try {
     setState('loading');
 
-    const { default: Auth } = await import(
-      /* webpackChunkName: "Amplify" */ '@aws-amplify/auth'
-    );
+    await signUp(data, context);
 
-    // We have to “generate” a password for them, because a password is required by Amazon Cognito when users sign up
-    const { userSub: userId } = await Auth.signUp({
-      username: data.email.toLowerCase(),
-      password: getRandomString(30),
-    });
+    // User did not exist
+    await signIn(data, context);
 
-    data.referral = getReferral();
-
-    // After we signed up via cognito, we want to create the user in dynamo
-    await createUser({ userId, ...data });
-
-    //we want to set the newly generated id
-    setUserId(userId);
     setState('success');
   } catch (error) {
-    //We have to check, if the error happened due to the user already existing
+    // We have to check, if the error happened due to the user already existing.
+    // If that's the case we call signIn() anyway.
     if (error.code === 'UsernameExistsException') {
-      // Save email, so we can use it for sign in later
-      setTempEmail(data.email);
-      setState('userExists');
+      try {
+        await signIn(data, context);
+        setState('success');
+      } catch (error) {
+        console.log('Error while signing in', error);
+        setState('error');
+      }
     } else if (
       error.code === 'TooManyRequestsException' ||
       error.code === 'ThrottlingException'
@@ -93,33 +76,46 @@ const signUp = async (data, setState, { setUserId, setTempEmail }) => {
   }
 };
 
+// Amplifys Auth class is used to sign up user
+const signUp = async (data, { setUserId }) => {
+  const { default: Auth } = await import(
+    /* webpackChunkName: "Amplify" */ '@aws-amplify/auth'
+  );
+
+  // We have to “generate” a password for them, because a password is required by Amazon Cognito when users sign up
+  const { userSub: userId } = await Auth.signUp({
+    username: data.email.toLowerCase(),
+    password: getRandomString(30),
+    attributes: {
+      'custom:confirmed': 'false', // booleans not possible
+    },
+  });
+
+  data.referral = getReferral();
+
+  // After we signed up via cognito, we want to create the user in dynamo
+  await createUser({ userId, ...data });
+
+  //we want to set the newly generated id
+  setUserId(userId);
+};
+
 // Sign in user through AWS Cognito (passwordless)
-const signIn = async (setState, { setCognitoUser, userId, tempEmail }) => {
-  try {
-    setState('loading');
+const signIn = async ({ email }, { setCognitoUser, userId }) => {
+  const { default: Auth } = await import(
+    /* webpackChunkName: "Amplify" */ '@aws-amplify/auth'
+  );
 
-    const { default: Auth } = await import(
-      /* webpackChunkName: "Amplify" */ '@aws-amplify/auth'
-    );
+  // If no email was passed we use the userId from context
+  const param = email ? email.toLowerCase() : userId;
 
-    // This will initiate the custom flow, which will lead to the user receiving a mail.
-    // The code will timeout after 3 minutes (enforced server side by AWS Cognito).
-    const user = await Auth.signIn(userId || tempEmail.toLowerCase());
+  // This will initiate the custom flow, which will lead to the user receiving a mail.
+  // The code will timeout after 3 minutes (enforced server side by AWS Cognito).
+  const user = await Auth.signIn(param);
 
-    // We already set the user here in the global context,
-    // because we need the object in answerCustomChallenge()
-    setCognitoUser(user);
-    setState('success');
-  } catch (error) {
-    if (error.code === 'UserNotFoundException') {
-      setState('userNotFound');
-    } else if (error.code === 'UserNotConfirmedException') {
-      setState('userNotConfirmed');
-    } else {
-      setState('error');
-    }
-    console.log('Error while signing in', error);
-  }
+  // We already set the user here in the global context,
+  // because we need the object in answerCustomChallenge()
+  setCognitoUser(user);
 };
 
 //Function, which uses the amplify api to sign out user

--- a/src/pages/playground/karte.js
+++ b/src/pages/playground/karte.js
@@ -21,7 +21,7 @@ export default () => {
               mapConfig={{
                 state: 'berlin',
                 config: {
-                  bounds: [
+                  maxBounds: [
                     [3, 47.217923],
                     [17.030017, 55.437655],
                   ],

--- a/src/pages/playground/pledge.js
+++ b/src/pages/playground/pledge.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import Layout from '../../components/Layout';
+import { Helmet } from 'react-helmet-async';
+import {
+  SectionWrapper,
+  Section,
+  SectionInner,
+} from '../../components/Layout/Sections';
+import Pledge from '../../components/Forms/Pledge';
+
+export default () => {
+  return (
+    <Layout>
+      <Helmet>
+        <title>Playground</title>
+      </Helmet>
+      <SectionWrapper>
+        <Section title="Pledge">
+          <SectionInner wide={true}>
+            <Pledge pledgeId="berlin-1" />
+          </SectionInner>
+        </Section>
+      </SectionWrapper>
+    </Layout>
+  );
+};

--- a/src/pages/playground/signIn.js
+++ b/src/pages/playground/signIn.js
@@ -30,7 +30,7 @@ export default () => {
                 <form
                   onSubmit={e => {
                     e.preventDefault();
-                    signIn(email);
+                    signIn({ email });
                   }}
                 >
                   <input

--- a/src/pages/unterschriftenliste/index.js
+++ b/src/pages/unterschriftenliste/index.js
@@ -24,11 +24,14 @@ const Unterschriftenliste = () => {
   }, []);
 
   useEffect(() => {
-    if (campaignCode && userId && isAuthenticated !== undefined) {
-      createPdf({
-        campaignCode,
-        userExists: true,
-      });
+    if (campaignCode && userId) {
+      if (isAuthenticated) {
+        createPdf({
+          campaignCode,
+          userExists: true,
+          shouldNotUpdateUser: true,
+        });
+      }
     }
   }, [isAuthenticated, userId, campaignCode]);
 
@@ -62,7 +65,7 @@ const Unterschriftenliste = () => {
               Da ist was schief gegangen
             </FinallyMessage>
           )}
-          {state === 'unauthorized' && (
+          {isAuthenticated === false && (
             <EnterLoginCode>
               <p>
                 Hey, wir kennen dich schon! Bitte gib den Code ein, den wir dir


### PR DESCRIPTION
Resolves: https://trello.com/c/Zu19BEqH/734-registrierung-zu-passwordless-login-umbauen

When a new user signs up, the sign in flow is immediately called as well by sending the login code to the user. There the user flow for signing up and signing in is basically the same. 

The flow for the confirmation changed as well: users are already flagged as confirmed in cognito when signing up. But I introduced a separate confirmed flag in dynamo db. This flag is set to true as soon as the user has entered the correct login code and is thereby authenticated. 

The pr has to be tested locally because the backend is only deployed to dev stage so far. 

To test: 
- Downloading a signature list as authenticated user, non-authenticated user, identified user (by passing a user id as url param) and new user
- Signing up (https://expedition-grundeinkommen.de/#generalpledge) non-authenticated user and new user
- Signing in ("Einloggen" in the top right corner) as authenticated user and non-authenticated user