### PR TITLE
Map support center and zoom.

### DIFF
--- a/src/components/Maps/LazyMap.js
+++ b/src/components/Maps/LazyMap.js
@@ -21,6 +21,36 @@ const DEFAULT_BOUNDS = [
   [17.030017, 55.437655],
 ];
 
+/**
+ * The `config` field on a contentful map object takes values that will be directly
+ * passed in to the mapboxgl map constructor. This function adds properties to the default mapbox config,
+ * only adding properties that have a value on the backend.
+ *
+ * @param {{}} defaultConfig Default mapbox config to add props to
+ * @param {{key: string; value: any}[]} props Props that get added to or override default config
+ */
+const addPropsToMapboxConfig = (defaultConfig, props) => {
+  if (!props) return defaultConfig;
+
+  // Loop through each key of each prop
+  const configWithoutNulls = Object.keys(props).reduce((acc, key) => {
+    // If value, add to accumulator
+    if (props[key]) {
+      return {
+        ...acc,
+        [key]: props[key],
+      };
+    }
+    // Otherwise, return accumulator
+    return acc;
+  }, {});
+
+  return {
+    ...defaultConfig,
+    ...configWithoutNulls,
+  };
+};
+
 export default ({ mapConfig }) => {
   const {
     allContentfulSammelort: { edges: collectSignaturesLocations },
@@ -73,11 +103,22 @@ export default ({ mapConfig }) => {
           return location.state === mapConfig.state;
         });
 
-      map = new mapboxgl.Map({
+      // Default config for mapboxgl
+      const mapboxConfigDefault = {
         container: container.current,
         style: 'mapbox://styles/mapbox/streets-v9',
-        maxBounds: mapConfig.config?.bounds || DEFAULT_BOUNDS,
-      }).addControl(new mapboxgl.NavigationControl(), 'top-left');
+        maxBounds: DEFAULT_BOUNDS,
+      };
+
+      const mapboxConfig = addPropsToMapboxConfig(
+        mapboxConfigDefault,
+        mapConfig.config
+      );
+
+      map = new mapboxgl.Map(mapboxConfig).addControl(
+        new mapboxgl.NavigationControl(),
+        'top-left'
+      );
 
       collectSignaturesLocationsFiltered.forEach(({ node: location }) => {
         if (location.location) {

--- a/src/components/Maps/LazyMap.js
+++ b/src/components/Maps/LazyMap.js
@@ -22,9 +22,9 @@ const DEFAULT_BOUNDS = [
 ];
 
 /**
- * The `config` field on a contentful map object takes values that will be directly
- * passed in to the mapboxgl map constructor. This function adds properties to the default mapbox config,
- * only adding properties that have a value on the backend.
+ * The `config` JSON field on a Contentful Map takes values that will be directly
+ * passed in to the mapboxgl map constructor. This function extends the default mapbox config
+ * only adding or overriding any properties that have a value on Contentful.
  *
  * @param {{}} defaultConfig Default mapbox config to add props to
  * @param {{key: string; value: any}[]} props Props that get added to or override default config
@@ -45,6 +45,7 @@ const addPropsToMapboxConfig = (defaultConfig, props) => {
     return acc;
   }, {});
 
+  // Merge Contentful properties with the default
   return {
     ...defaultConfig,
     ...configWithoutNulls,

--- a/src/components/StaticPage/index.js
+++ b/src/components/StaticPage/index.js
@@ -71,6 +71,8 @@ export const pageQuery = graphql`
               state
               config {
                 bounds
+                zoom
+                center
               }
             }
             callToActionLink


### PR DESCRIPTION
**Required changes in Contentful**: All map objects need to have their config values updated. `bounds` should become `maxBounds`.

This allows the `<LoadableMap />` component to support setting a center and zoom from Contentful. 

It also makes the Contentful map config field's values passed directly in to the mapboxgl config. This means that any property supported by mapbox can be set in the Contentful config, and it will be applied. Make sure to update the query at `src/StaticPage` however.

By the way HIIII @Valioesi :) :) 