### PR TITLE
Save newsletter settings when downloading list

### DIFF
--- a/src/components/Forms/SignatureListDownload/index.js
+++ b/src/components/Forms/SignatureListDownload/index.js
@@ -1,7 +1,13 @@
 import React, { useEffect, useState, useContext } from 'react';
 import { Form, Field } from 'react-final-form';
 import { TextInputWrapped } from '../TextInput';
-import { validateEmail, addActionTrackingId, trackEvent } from '../../utils';
+import {
+  validateEmail,
+  addActionTrackingId,
+  trackEvent,
+  mapCampaignCodeToAgs,
+  mapCampaignCodeToState,
+} from '../../utils';
 import s from './style.module.less';
 import { CTAButton, CTAButtonContainer } from '../../Layout/CTAButton';
 import { LinkButton, InlineButton } from '../Button';
@@ -164,7 +170,19 @@ export default ({ signaturesId, disableRequestListsByMail }) => {
 
           // If user is not identified
           setEmail(e.email);
-          signUp({ newsletterConsent: true, ...e });
+          signUp({
+            newsletterConsent: true,
+            customNewsletters: [
+              {
+                municipalityName: mapCampaignCodeToState(signaturesId),
+                value: true,
+                extraInfo: false,
+                timestamp: new Date().toISOString(),
+                ags: mapCampaignCodeToAgs(signaturesId),
+              },
+            ],
+            ...e,
+          });
         }}
         validate={values => validate(values, userId)}
         render={({ handleSubmit }) => {

--- a/src/components/Forms/SignatureListDownload/index.js
+++ b/src/components/Forms/SignatureListDownload/index.js
@@ -174,7 +174,7 @@ export default ({ signaturesId, disableRequestListsByMail }) => {
             newsletterConsent: true,
             customNewsletters: [
               {
-                municipalityName: mapCampaignCodeToState(signaturesId),
+                name: mapCampaignCodeToState(signaturesId),
                 value: true,
                 extraInfo: false,
                 timestamp: new Date().toISOString(),

--- a/src/components/utils/index.js
+++ b/src/components/utils/index.js
@@ -156,3 +156,15 @@ export function getMailtoUrl(to, subject, body) {
   }
   return url;
 }
+
+const stateToAgs = {
+  berlin: '11000000',
+  bremen: '04011000',
+  hamburg: '02000000',
+};
+
+// Map campaign code to ags by extracting state out of campaign code
+// ad mapping that state to the ags
+export function mapCampaignCodeToAgs(campaignCode) {
+  return stateToAgs[campaignCode.split('-')[0]];
+}


### PR DESCRIPTION
This is necessary for the new communication settings structure. When a new user downloads a list they will are simultaneously subscribing to the newsletter for that state. 

For future reference: we might also need to do something similar for our general sign up form. We can talk about that in the next sprint planning for example 