### PR TITLE
Hook to get stats for municipalities

### DIFF
--- a/src/hooks/Api/Municipalities/index.js
+++ b/src/hooks/Api/Municipalities/index.js
@@ -1,0 +1,52 @@
+/**
+ * This file holds the hook(s) needed for the stats of municipalities
+ */
+
+import { useState } from 'react';
+import CONFIG from '../../../../aws-config';
+
+export const useGetMunicipalityStats = () => {
+  const [state, setState] = useState();
+  const [stats, setStats] = useState({});
+
+  return [
+    state,
+    stats,
+    (ags = null) => getMunicipalityStats(ags, setState, setStats),
+  ];
+};
+
+// This function fetches the municipality stats from the backend.
+// Depending on whether an ags is passed stats for just one munic. or for all is fetched.
+const getMunicipalityStats = async (ags, setState, setStats) => {
+  try {
+    setState('loading');
+
+    // Make request to api to save question
+    const request = {
+      method: 'GET',
+      mode: 'cors',
+    };
+
+    const endpoint = ags
+      ? `/analytics/municipalities/${ags}`
+      : '/analytics/municipalities';
+
+    const response = await fetch(
+      `${CONFIG.API.INVOKE_URL}${endpoint}`,
+      request
+    );
+
+    if (response.status === 200) {
+      const { data } = await response.json();
+      setState('success');
+      setStats(data);
+    } else {
+      console.log('Api response not 200');
+      setState('error');
+    }
+  } catch (error) {
+    console.log('Error', error);
+    setState('error');
+  }
+};

--- a/src/pages/playground/municipalityHook.js
+++ b/src/pages/playground/municipalityHook.js
@@ -1,0 +1,35 @@
+import React, { useEffect } from 'react';
+import Layout from '../../components/Layout';
+import { Helmet } from 'react-helmet-async';
+import {
+  SectionWrapper,
+  Section,
+  SectionInner,
+} from '../../components/Layout/Sections';
+import { useGetMunicipalityStats } from '../../hooks/Api/Municipalities';
+
+export default () => {
+  const [state1, stats1, getMunicipalityStats1] = useGetMunicipalityStats();
+  const [state2, stats2, getMunicipalityStats2] = useGetMunicipalityStats();
+
+  useEffect(() => {
+    getMunicipalityStats1();
+    getMunicipalityStats2('091088');
+  }, []);
+
+  console.log({ stats1 }, { state1 });
+  console.log({ stats2 }, { state2 });
+
+  return (
+    <Layout>
+      <Helmet>
+        <title>Playground</title>
+      </Helmet>
+      <SectionWrapper>
+        <Section title="hook">
+          <SectionInner wide={true}></SectionInner>
+        </Section>
+      </SectionWrapper>
+    </Layout>
+  );
+};


### PR DESCRIPTION
Resolves: https://trello.com/c/DuEWV4p9/772-hook-f%C3%BCr-gemeindestatistiken-05

Pretty self explanatory. The one hook can be used for both endpoint (1. /analytics/municipalities, 2. /analytics/municipalities/{ags})

To test: go to /playground/municipalityHook and check the logs (only locally because the backend is only deployed to dev so far) 