### PR TITLE
Fixed issue when resending code after 3 min

### DIFF
--- a/src/components/Login/EnterLoginCode/index.js
+++ b/src/components/Login/EnterLoginCode/index.js
@@ -42,6 +42,9 @@ export const EnterLoginCode = ({
       isAuthenticated
     ) {
       onAnswerChallengeSuccess();
+    } else if (answerChallengeState === 'restartSignIn') {
+      // We want to send a new code by starting sign in again
+      startSignIn();
     }
   }, [answerChallengeState, isAuthenticated]);
 
@@ -112,7 +115,8 @@ export const EnterLoginCode = ({
         </p>
       )}
 
-      {answerChallengeState === 'resentCode' && (
+      {(answerChallengeState === 'resentCode' ||
+        answerChallengeState === 'restartSignIn') && (
         <p>
           Der Code wurde erneut per E-Mail {tempEmail ? ` (${tempEmail})` : ''}{' '}
           geschickt.

--- a/src/hooks/Authentication/AnswerChallenge/index.js
+++ b/src/hooks/Authentication/AnswerChallenge/index.js
@@ -62,11 +62,18 @@ const answerCustomChallenge = async (
       console.log('Apparently the user did not enter the right code', error);
     }
   } catch (error) {
-    setState('wrongCode');
-    console.log(
-      'User entered wrong code three times or user was never set',
-      error
-    );
+    // If we wanted to resend the code after used waited more than 3 minutes
+    // this error will be thrown. In this case we should login again and therefore
+    // send a new code
+    if (answer === 'resendCode') {
+      setState('restartSignIn');
+    } else {
+      setState('wrongCode');
+      console.log(
+        'User entered wrong code three times or user was never set',
+        error
+      );
+    }
   }
 };
 


### PR DESCRIPTION
There was an issue if a user wants to resend the code but has waited more than 3 minutes. In that case an error because of invalid session was thrown by Amplify. This is now caught and the sign in process is started again. A new code is sent.

To test: sign in as usual, sign in after resending code, resend code after waiting more than 3 minutes and sign in then. 