### PR TITLE
Send code immediately if opening profile unauthenticated

### DIFF
--- a/src/components/Profile/ProfileWrapper/index.js
+++ b/src/components/Profile/ProfileWrapper/index.js
@@ -23,6 +23,7 @@ const ProfilePage = ({ id: slugId }) => {
   const {
     userId,
     isAuthenticated,
+    setUserId,
     customUserData: userData,
     previousAction,
     setPreviousAction,
@@ -43,8 +44,13 @@ const ProfilePage = ({ id: slugId }) => {
     // If user isn't authenticated
     if (isAuthenticated === false) {
       setIsLoading(false);
+
+      // Set user id to slug id, so people get immediately sent the login code.
+      // This is relevant if people click a link in a newsletter to update contact settings.
+      setUserId(slugId);
     } else if (isAuthenticated) {
       if (userId !== slugId) {
+        console.log('bouncing');
         // We want to tell the user that they are trying to view the page
         // of a different user. Furthermore we want to bounce the user back
         // to the identified state.

--- a/src/components/Profile/ProfileWrapper/index.js
+++ b/src/components/Profile/ProfileWrapper/index.js
@@ -50,7 +50,6 @@ const ProfilePage = ({ id: slugId }) => {
       setUserId(slugId);
     } else if (isAuthenticated) {
       if (userId !== slugId) {
-        console.log('bouncing');
         // We want to tell the user that they are trying to view the page
         // of a different user. Furthermore we want to bounce the user back
         // to the identified state.


### PR DESCRIPTION
Send the login code without prompting email address if user visits profile while not authenticated. This is done through: Set user id to slug id, so people get immediately sent the login code.

This is relevant if people click a link in a newsletter to update contact settings.