### PR TITLE
Donation feature fixes

### DIFF
--- a/src/components/Forms/DonationForm/index.js
+++ b/src/components/Forms/DonationForm/index.js
@@ -25,9 +25,7 @@ import { FinallyMessage } from '../FinallyMessage';
 import Confetti from '../../Confetti';
 import { validateEmail } from '../../utils';
 
-export default theme => {
-  // var themeClass = theme[Object.keys(theme)[0]];
-
+export default ({ onboardingNextPage }) => {
   const {
     isAuthenticated,
     tempEmail,
@@ -517,6 +515,19 @@ export default theme => {
                             Expedition Grundeinkommen erhält davon 4,83 € bzw.
                             9,83 €.
                           </p>
+
+                          <div className={s.donationButtons}>
+                            <CTAButton
+                              type="submit"
+                              onClick={() => {
+                                onboardingNextPage();
+                              }}
+                              size="MEDIUM"
+                              className={s.primaryButton}
+                            >
+                              Weiter
+                              </CTAButton>
+                          </div>
                         </div>
                       )}
                     </form>
@@ -685,9 +696,23 @@ export default theme => {
             deinem Konto einziehen.
           </p>
           <p>Vielen Dank, dass du die Expedition unterstützt! </p>
-          <CTAButtonContainer className={s.buttonContainer}>
-            <CTALink to="/">Zur Startseite</CTALink>
-          </CTAButtonContainer>
+          {!onboardingNextPage ?
+            <CTAButtonContainer className={s.buttonContainer}>
+              <CTALink to="/">Zur Startseite</CTALink>
+            </CTAButtonContainer> :
+            <div className={s.donationButtons}>
+              <CTAButton
+                type="submit"
+                onClick={() => {
+                  onboardingNextPage();
+                }}
+                size="MEDIUM"
+                className={s.primaryButton}
+              >
+                Weiter
+            </CTAButton>
+            </div>
+          }
 
           <Confetti></Confetti>
         </div>

--- a/src/components/Onboarding/Donate/index.js
+++ b/src/components/Onboarding/Donate/index.js
@@ -47,55 +47,55 @@ export const Donate = ({
     <section className={gS.pageContainer}>
       {showDonationForm ? (
         <>
-          <DonationForm theme={{}} />
+          <DonationForm onboardingNextPage={() => setCurrentElementByIndex(compIndex + 1)} />
         </>
       ) : (
-        <>
-          <h3 className={gS.moduleTitle}>
-            Mach die Expedition mit deiner Spende möglich
-          </h3>
-          <p className={gS.descriptionTextLarge}>
-            Die Expedition ist gemeinnützig und spendenfinanziert. Sie gibt es
-            nur, wenn alle etwas in die Reisekasse legen. Spende jetzt, damit
-            wir gemeinsam das Grundeinkommen in {municipality.name} und ganz
-            Deutschland Wirklichkeit werden lassen!
-          </p>
+          <>
+            <h3 className={gS.moduleTitle}>
+              Mach die Expedition mit deiner Spende möglich
+            </h3>
+            <p className={gS.descriptionTextLarge}>
+              Die Expedition ist gemeinnützig und spendenfinanziert. Sie gibt es
+              nur, wenn alle etwas in die Reisekasse legen. Spende jetzt, damit
+              wir gemeinsam das Grundeinkommen in {municipality.name} und ganz
+              Deutschland Wirklichkeit werden lassen!
+            </p>
 
-          <div className={gS.buttonRow}>
-            <div
-              aria-hidden="true"
-              className={s.engagementOption}
-              onClick={() => setShowDonationForm(true)}
-            >
-              Jetzt spenden
+            <div className={gS.buttonRow}>
+              <div
+                aria-hidden="true"
+                className={s.engagementOption}
+                onClick={() => setShowDonationForm(true)}
+              >
+                Jetzt spenden
             </div>
 
-            <div
-              aria-hidden="true"
-              className={s.engagementOption}
-              onClick={() => {
-                saveDonationReaction('remindMeLater');
-                setCurrentElementByIndex(compIndex + 1);
-              }}
-            >
-              Später erinnern
+              <div
+                aria-hidden="true"
+                className={s.engagementOption}
+                onClick={() => {
+                  saveDonationReaction('remindMeLater');
+                  setCurrentElementByIndex(compIndex + 1);
+                }}
+              >
+                Später erinnern
+              </div>
             </div>
-          </div>
 
-          <div className={gS.fullWidthFlex}>
-            <span
-              aria-hidden="true"
-              className={gS.linkLikeFormatted}
-              onClick={() => {
-                saveDonationReaction('skipedDonation');
-                setCurrentElementByIndex(compIndex + 1);
-              }}
-            >
-              Überspringen
-            </span>
-          </div>
-        </>
-      )}
+            <div className={gS.fullWidthFlex}>
+              <span
+                aria-hidden="true"
+                className={gS.linkLikeFormatted}
+                onClick={() => {
+                  saveDonationReaction('skipedDonation');
+                  setCurrentElementByIndex(compIndex + 1);
+                }}
+              >
+                Überspringen
+              </span>
+            </div>
+          </>
+        )}
     </section>
   );
 };


### PR DESCRIPTION
Mehrere Glitches:

Wenn ich Überweisung auswähle, fehlt der Knopf mit (Weiter). Dadurch ist hier im Schlauch eine Sackgasse.

Wenn ich Lastschrift auswähle, und alles bestätigt habe (mit „Jetzt spenden“), steht im Danke-Screen der Button (Zur Startseite) - müsste (Weiter) heißen.

Wenn ich dann (Zur Startseite) klicke, komme ich zurück an den Anfang des Spendenschlauchs, sollte aber weiter zum nächsten Schlauchschritt „Teilen“ kommen.