### PR TITLE
Fix signout

### DIFF
--- a/src/components/Forms/SignUp/index.js
+++ b/src/components/Forms/SignUp/index.js
@@ -53,7 +53,7 @@ export default ({
 
   let prefilledZip;
 
-  if (municipalityInForm?.zipCodes.length === 1) {
+  if (municipalityInForm?.zipCodes?.length === 1) {
     prefilledZip = municipalityInForm?.zipCodes[0];
   } else if (userData?.zipCode) {
     prefilledZip = userData.zipCode;

--- a/src/context/Authentication/index.js
+++ b/src/context/Authentication/index.js
@@ -97,6 +97,10 @@ const AuthProvider = ({ children }) => {
         setCustomUserData,
         signUserOut,
       });
+    } else if (!userId && !isAuthenticated) {
+      // If userId is not set and is Authenticated is not true,
+      // we want to reset userData (this would happen after a signout)
+      setCustomUserData({});
     }
   }, [userId, isAuthenticated]);
 


### PR DESCRIPTION
Resolves: https://expedition-grundeinkommen.monday.com/boards/853311751/pulses/1090240008?userId=17160996

1. Update user data when signing out
2. Check in form if zip codes is defined. This is more of a hotfix, because zip codes should always be there, but for some reason the municipality in the context does not contain zip codes anymore after signing out. I am looking into it...

To test:
1. Sign up for municipality -> stay on municipality page -> sign out -> open form and try signing up for municipality again
2. Sign in -> go to one of your municipalities -> sign out -> open form and try signing up for municipality again