### PR TITLE
hotfix link error in newsletter

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,6 +1,6 @@
 https://www.expedition-grundeinkommen.com/*     https://expedition-grundeinkommen.de/:splat 301!
 http://www.expedition-grundeinkommen.com/*      https://expedition-grundeinkommen.de/:splat 301!
-www.expedition-grundeinkommen.com/*      https://expedition-grundeinkommen.de/:splat 301!
+www.expedition-grundeinkommen.com/*             https://expedition-grundeinkommen.de/:splat 301!
 
 https://expedition-grundeinkommen.de/gemeinde-teilen/*  https://ag5gu1z06h.execute-api.eu-central-1.amazonaws.com/prod/share-municipality/:splat 200
 /gemeinde-teilen/*  https://2j0bcp5tr9.execute-api.eu-central-1.amazonaws.com/dev/share-municipality/:splat 200
@@ -9,3 +9,4 @@ https://expedition-grundeinkommen.de/gemeinde-teilen/*  https://ag5gu1z06h.execu
 /berlin                                         /gemeinden/berlin
 /hamburg                                        /gemeinden/hamburg
 /bremen                                         /gemeinden/bremen
+/teilen/:userId                                 /teilen/?userId=:userId


### PR DESCRIPTION
Newsletter link is /teilen/:userId, should be /teilen/?userId=:userId