### PR TITLE
Section component text image

### DIFF
--- a/src/components/Layout/Sections/SectionComponentTextAndImage/index.js
+++ b/src/components/Layout/Sections/SectionComponentTextAndImage/index.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { contentfulJsonToHtml } from '../../../utils/contentfulJsonToHtml';
+import Img from 'gatsby-image';
+
+export const SectionComponentTextAndImage = ({ text, image }) => {
+  return (
+    <>
+      {image && image.fluid && <Img fluid={image.fluid} />}
+      {text && <div>{contentfulJsonToHtml(text.json)}</div>}
+    </>
+  );
+};

--- a/src/components/Layout/Sections/TextAndImage/index.js
+++ b/src/components/Layout/Sections/TextAndImage/index.js
@@ -7,7 +7,7 @@ import cN from 'classnames';
 export const TextAndImage = ({ layout, text, image }) => {
   return (
     <div
-      className={cN(s.container, { [s.imageRight]: layout === 'imageRight' })}
+      className={cN(s.container, { [s.imageRight]: layout === 'ImageRight' })}
     >
       {image && image.fluid && <Img className={s.image} fluid={image.fluid} />}
       {text && <div className={s.text}>{contentfulJsonToHtml(text.json)}</div>}

--- a/src/components/Layout/Sections/TextAndImage/index.js
+++ b/src/components/Layout/Sections/TextAndImage/index.js
@@ -2,10 +2,13 @@ import React from 'react';
 import { contentfulJsonToHtml } from '../../../utils/contentfulJsonToHtml';
 import Img from 'gatsby-image';
 import s from './style.module.less';
+import cN from 'classnames';
 
-export const TextAndImage = ({ text, image }) => {
+export const TextAndImage = ({ layout, text, image }) => {
   return (
-    <div className={s.container}>
+    <div
+      className={cN(s.container, { [s.imageRight]: layout === 'imageRight' })}
+    >
       {image && image.fluid && <Img className={s.image} fluid={image.fluid} />}
       {text && <div className={s.text}>{contentfulJsonToHtml(text.json)}</div>}
     </div>

--- a/src/components/Layout/Sections/TextAndImage/index.js
+++ b/src/components/Layout/Sections/TextAndImage/index.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import { contentfulJsonToHtml } from '../../../utils/contentfulJsonToHtml';
 import Img from 'gatsby-image';
+import s from './style.module.less';
 
 export const TextAndImage = ({ text, image }) => {
   return (
-    <>
-      {image && image.fluid && <Img fluid={image.fluid} />}
-      {text && <div>{contentfulJsonToHtml(text.json)}</div>}
-    </>
+    <div className={s.container}>
+      {image && image.fluid && <Img className={s.image} fluid={image.fluid} />}
+      {text && <div className={s.text}>{contentfulJsonToHtml(text.json)}</div>}
+    </div>
   );
 };

--- a/src/components/Layout/Sections/TextAndImage/index.js
+++ b/src/components/Layout/Sections/TextAndImage/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { contentfulJsonToHtml } from '../../../utils/contentfulJsonToHtml';
 import Img from 'gatsby-image';
 
-export const SectionComponentTextAndImage = ({ text, image }) => {
+export const TextAndImage = ({ text, image }) => {
   return (
     <>
       {image && image.fluid && <Img fluid={image.fluid} />}

--- a/src/components/Layout/Sections/TextAndImage/style.module.less
+++ b/src/components/Layout/Sections/TextAndImage/style.module.less
@@ -7,6 +7,10 @@
   width: 100%;
 }
 
+.imageRight {
+  flex-direction: row-reverse;
+}
+
 .image {
   width: 100%;
 

--- a/src/components/Layout/Sections/TextAndImage/style.module.less
+++ b/src/components/Layout/Sections/TextAndImage/style.module.less
@@ -1,0 +1,22 @@
+@import '../../../style/vars.less';
+
+.container {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.image {
+  width: 100%;
+
+  @media (min-width: @breakPointS) {
+    width: 25%;
+  }
+}
+
+.text {
+  @media (min-width: @breakPointS) {
+    width: 75%;
+  }
+}

--- a/src/components/Layout/Sections/index.js
+++ b/src/components/Layout/Sections/index.js
@@ -38,6 +38,7 @@ import { IntroText } from '../../IntroText';
 import { BecomeActive } from '../../BecomeActive';
 import { ProfileTile } from '../../Profile/ProfileTile';
 import { StandardSectionComponent } from './StandardSectionComponent';
+import { SectionComponentTextAndImage } from './SectionComponentTextAndImage';
 
 import { LinkButton } from '../../Forms/Button';
 
@@ -50,6 +51,7 @@ const Components = {
   IntroText,
   BecomeActive,
   ProfileTile,
+  SectionComponentTextAndImage,
   Standard: StandardSectionComponent,
 };
 

--- a/src/components/Layout/Sections/index.js
+++ b/src/components/Layout/Sections/index.js
@@ -38,7 +38,7 @@ import { IntroText } from '../../IntroText';
 import { BecomeActive } from '../../BecomeActive';
 import { ProfileTile } from '../../Profile/ProfileTile';
 import { StandardSectionComponent } from './StandardSectionComponent';
-import { SectionComponentTextAndImage } from './SectionComponentTextAndImage';
+import { TextAndImage } from './TextAndImage';
 
 import { LinkButton } from '../../Forms/Button';
 
@@ -51,7 +51,7 @@ const Components = {
   IntroText,
   BecomeActive,
   ProfileTile,
-  SectionComponentTextAndImage,
+  TextAndImage,
   Standard: StandardSectionComponent,
 };
 

--- a/src/components/StaticPage/index.js
+++ b/src/components/StaticPage/index.js
@@ -181,6 +181,20 @@ export const pageQuery = graphql`
                   json
                 }
               }
+              ... on ContentfulSectionComponentTextAndImage {
+                __typename
+                title
+                showForOptions
+                layout
+                image {
+                  fluid(maxWidth: 500, quality: 90) {
+                    ...GatsbyContentfulFluid
+                  }
+                }
+                text {
+                  json
+                }
+              }
               ... on ContentfulSectionComponentTickerToSignup {
                 __typename
                 title

--- a/src/components/StaticPage/index.js
+++ b/src/components/StaticPage/index.js
@@ -185,6 +185,7 @@ export const pageQuery = graphql`
                 __typename
                 title
                 showForOptions
+                column
                 layout
                 image {
                   fluid(maxWidth: 500, quality: 90) {


### PR DESCRIPTION
Added a new contentful section that allows users to have a small image next to a bigger text. image can be left or right, component can be narrow or wide.
To test: Check out the section "Warum 1%?" on /bürgerbegehren. 
It should show up twice (old and new). I will delete the old section in Contentful before merging.
