### PR TITLE
Changed verification page to use new custom api endpoint

### DIFF
--- a/src/hooks/Authentication/Verification/index.js
+++ b/src/hooks/Authentication/Verification/index.js
@@ -1,59 +1,39 @@
 import { useState } from 'react';
+import CONFIG from '../../../../aws-config';
 
 export const useVerification = () => {
   const [verificationState, setVerificationState] = useState('verifying');
   return [
     verificationState,
-    (email, code) => confirmSignUp(email, code, setVerificationState),
-    email => resendEmail(email, setVerificationState),
+    (userId, token) => confirmSignUp(userId, token, setVerificationState),
   ];
 };
 
 // Amplifys Auth Class is used to send a confirmation code to verify the mail address
-const confirmSignUp = async (email, confirmationCode, setVerificationState) => {
+const confirmSignUp = async (userId, token, setVerificationState) => {
   try {
-    const { default: Auth } = await import(
-      /* webpackChunkName: "Amplify" */ '@aws-amplify/auth'
+    const request = {
+      method: 'POST',
+      mode: 'cors',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ token }),
+    };
+
+    const response = await fetch(
+      `${CONFIG.API.INVOKE_URL}/users/${userId}/confirm`,
+      request
     );
 
-    //use auth class to confirm sing up
-    await Auth.confirmSignUp(email.toLowerCase(), confirmationCode);
-    setVerificationState('verified');
-    return true;
-  } catch (error) {
-    console.log('error confirming email', error);
-    const errorCode = error.code;
-    if (errorCode === 'UserNotFoundException') {
+    if (response.status === 204) {
+      setVerificationState('verified');
+    } else if (response.status === 404) {
       setVerificationState('userNotFound');
-    } else if (errorCode === 'CodeMismatchException') {
-      setVerificationState('wrongCode');
-    } else if (errorCode === 'NotAuthorizedException') {
-      setVerificationState('alreadyVerified');
-    } else if (errorCode === 'ExpiredCodeException') {
-      setVerificationState('expiredCode');
     } else {
       setVerificationState('error');
     }
-    return false;
-  }
-};
-
-// Amplifys Auth Class is used to resend the confirmation mail
-const resendEmail = async (email, setVerificationState) => {
-  try {
-    setVerificationState('resendingEmail');
-
-    const { default: Auth } = await import(
-      /* webpackChunkName: "Amplify" */ '@aws-amplify/auth'
-    );
-
-    await Auth.resendSignUp(email);
-    setVerificationState('resentEmail');
-    return true;
   } catch (error) {
-    console.log('error resending confirmation mail');
     setVerificationState('error');
-    //TODO: more specific error states
-    return false;
   }
 };

--- a/src/pages/verifizierung/index.js
+++ b/src/pages/verifizierung/index.js
@@ -6,14 +6,17 @@ import SocialMediaButtons from '../../components/SocialMedia/Share';
 import s from './style.module.less';
 import { HurrayCrowd } from '../../components/HurrayCrowd';
 import cN from 'classnames';
-import { Button } from '../../components/Forms/Button';
 import { CTALink } from '../../components/Layout/CTAButton';
 import querystring from 'query-string';
 
 const Verification = () => {
-  const [verificationState, confirmSignUp, resendEmail] = useVerification();
+  const [verificationState, confirmSignUp] = useVerification();
   const [urlParams, setUrlParams] = useState(null);
-  const urlParamsComplete = !!(urlParams && urlParams.code && urlParams.email);
+  const urlParamsComplete = !!(
+    urlParams &&
+    urlParams.userId &&
+    urlParams.token
+  );
 
   useEffect(() => {
     const params = querystring.parse(window.location.search);
@@ -23,7 +26,7 @@ const Verification = () => {
 
   useEffect(() => {
     if (urlParams) {
-      confirmSignUp(urlParams.email, urlParams.code);
+      confirmSignUp(urlParams.userId, urlParams.token);
     }
   }, [urlParams]);
 
@@ -31,20 +34,13 @@ const Verification = () => {
     verificationState can now be:
     - verifying
     - verified
-    - alreadyVerified
     - userNotFound
-    - wrongCode
-    - expiredCode
-    - resendingEmail
-    - resentEmail
     - error (which is every other error)
   */
 
-  const hasError = ['userNotFound', 'wrongCode', 'error'].includes(
-    verificationState
-  );
+  const hasError = ['userNotFound', 'error'].includes(verificationState);
 
-  const isOk = ['verified', 'alreadyVerified'].includes(verificationState);
+  const isOk = verificationState === 'verified';
 
   let finallyMessageState;
 
@@ -52,10 +48,7 @@ const Verification = () => {
     finallyMessageState = 'success';
   }
 
-  if (
-    verificationState === 'verifying' ||
-    verificationState === 'resendingEmail'
-  ) {
+  if (verificationState === 'verifying') {
     finallyMessageState = 'progress';
   }
 
@@ -92,38 +85,26 @@ const Verification = () => {
                   )}
                   {verificationState === 'userNotFound' && (
                     <>
-                      Wir haben "{urlParams.email}" nicht in unserer Datenbank
-                      gefunden. Ist die Registrierung vielleicht sehr lange her?
+                      Wir haben dich nicht in unserer Datenbank gefunden. Ist
+                      die Registrierung vielleicht sehr lange her?
                       <br />
                       <br />
                     </>
                   )}
-                  Probiere es bitte ein weiteres Mal oder melde dich bei uns mit
-                  dem Hinweis zu der genauen Fehlermeldung. Nenne uns bitte
-                  außerdem falls möglich deinen Browser und die Version:
-                  <br />
-                  <br />
-                  <a href="mailto:support@expedition-grundeinkommen.de">
-                    support@expedition-grundeinkommen.de
-                  </a>
+                  {verificationState === 'error' && urlParamsComplete && (
+                    <>
+                      Möglicherweise ist der Zeitraum der Verifizierung bereits
+                      abgelaufen. Melde dich einfach bei{' '}
+                      <a href="mailto:support@expedition-grundeinkommen.de">
+                        support@expedition-grundeinkommen.de
+                      </a>
+                      , dann können wir dich manuell verifizieren.
+                      <br />
+                      <br />
+                    </>
+                  )}
                 </>
               )}
-              {verificationState === 'expiredCode' && (
-                <>
-                  Dein Verifizierungslink ist abgelaufen. Bitte klicke diesen
-                  Button, um einen neuen zu erhalten: <br /> <br />
-                  <Button
-                    onClick={() => {
-                      resendEmail(urlParams.email);
-                    }}
-                  >
-                    Sende neue Verifizierungs-E-Mail
-                  </Button>
-                </>
-              )}
-              {verificationState === 'resendingEmail' && 'Sende neue E-Mail...'}
-              {verificationState === 'resentEmail' &&
-                'Wir haben dir eine neue E-Mail geschickt. Bitte klicke darin den Link, dann bist du dabei!'}
             </FinallyMessage>
           )}
           {isOk && (


### PR DESCRIPTION
The modified verification page now listens to url params userId and token. It sends them to a custom api endpoint (https://github.com/grundeinkommensbuero/backend/pull/102) to confirm the user.

To test: I have triggered an email to nicolai@expedition-grundeinkommen.de. Copy the params and open the /verifizierung page in a dev environment. Your user should get confirmed (maybe also check in db).
 