### PR TITLE
Removed unused title props from graphql query

### DIFF
--- a/src/components/StaticPage/index.js
+++ b/src/components/StaticPage/index.js
@@ -167,7 +167,6 @@ export const pageQuery = graphql`
             components {
               ... on ContentfulSectionComponentStandard {
                 __typename
-                title
                 showForOptions
                 column
                 videoLink
@@ -183,7 +182,6 @@ export const pageQuery = graphql`
               }
               ... on ContentfulSectionComponentTextAndImage {
                 __typename
-                title
                 showForOptions
                 column
                 layout
@@ -198,7 +196,6 @@ export const pageQuery = graphql`
               }
               ... on ContentfulSectionComponentTickerToSignup {
                 __typename
-                title
                 showForOptions
                 column
                 tickerDescription {
@@ -207,19 +204,16 @@ export const pageQuery = graphql`
               }
               ... on ContentfulSectionComponentMunicipalityMap {
                 __typename
-                title
                 showForOptions
                 column
               }
               ... on ContentfulSectionComponentMunicipalityProgress {
                 __typename
-                title
                 showForOptions
                 column
               }
               ... on ContentfulSectionComponentInviteFriends {
                 __typename
-                title
                 showForOptions
                 headline
                 column
@@ -229,7 +223,6 @@ export const pageQuery = graphql`
               }
               ... on ContentfulSectionComponentInviteFriends {
                 __typename
-                title
                 showForOptions
                 headline
                 column
@@ -239,7 +232,6 @@ export const pageQuery = graphql`
               }
               ... on ContentfulSectionComponentBecomeActive {
                 __typename
-                title
                 showForOptions
                 headline
                 column
@@ -250,14 +242,12 @@ export const pageQuery = graphql`
               }
               ... on ContentfulSectionComponentInfoText {
                 __typename
-                title
                 showForOptions
                 fullWidthOnDesktop
                 column
               }
               ... on ContentfulSectionComponentIntroText {
                 __typename
-                title
                 showForOptions
                 fullWidthOnDesktop
                 column
@@ -270,7 +260,6 @@ export const pageQuery = graphql`
               }
               ... on ContentfulSectionComponentProfileTile {
                 __typename
-                title
                 showForOptions
                 column
                 body {
@@ -282,14 +271,12 @@ export const pageQuery = graphql`
           }
           ... on ContentfulPageSectionDonation {
             __typename
-            title
             introText
             theme
             colorScheme
           }
           ... on ContentfulPageSectionShare {
             __typename
-            title
             introText
             colorScheme
             previewDescription {


### PR DESCRIPTION
Resolves: https://expedition-grundeinkommen.monday.com/boards/853311751/pulses/1189728360?userId=17160996

I removed the title props in the graphql queries of the section components, because they weren't used anyway for some reason. I already changed the names of the contentful fields for all section components (title to name), I haven't changed the field ids yet though, because this pr would need to be merged beforehand. 

To test: nothing really, because the site wouldn't build if there were issues due to the changes. 