### PR TITLE
Collection Map: use contentful component instead of hack

### DIFF
--- a/src/components/Layout/Sections/index.js
+++ b/src/components/Layout/Sections/index.js
@@ -33,6 +33,7 @@ import { TickerToSignup } from '../../TickerToSignup';
 import { MunicipalityMapAndSearch } from '../../Municipality/MunicipalityMapAndSearch';
 import { MunicipalityInfoText } from '../../Municipality/MunicipalityInfoText';
 import { MunicipalityProgress } from '../../Municipality/MunicipalityProgress';
+import { MunicipalityCollectionMap } from '../../Municipality/MunicipalityCollectionMap';
 import { InviteFriends } from '../../InviteFriends';
 import { IntroText } from '../../IntroText';
 import { BecomeActive } from '../../BecomeActive';
@@ -53,6 +54,7 @@ const Components = {
   ProfileTile,
   TextAndImage,
   Standard: StandardSectionComponent,
+  CollectionMap: MunicipalityCollectionMap,
 };
 
 export default function Sections({ sections, pageContext }) {

--- a/src/components/Municipality/MunicipalityCollectionMap/index.js
+++ b/src/components/Municipality/MunicipalityCollectionMap/index.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import Maps from '../../Maps';
+import { contentfulJsonToHtml } from '../../utils/contentfulJsonToHtml';
+
+export const MunicipalityCollectionMap = ({ text, maps }) => {
+  return (
+    <>
+      {text && <div>{contentfulJsonToHtml(text.json)}</div>}
+      {maps && <Maps config={maps} />}
+    </>
+  );
+};

--- a/src/components/Municipality/MunicipalityProgress/index.js
+++ b/src/components/Municipality/MunicipalityProgress/index.js
@@ -1,7 +1,6 @@
 import React, { useContext } from 'react';
 import { CampainVisualisation } from '../../CampaignVisualisations';
 import { MunicipalityContext } from '../../../context/Municipality';
-import Map from '../../Maps/Map';
 
 import s from './style.module.less';
 
@@ -57,34 +56,6 @@ export const MunicipalityProgress = ({
               Hol also noch Menschen dazu.
             </p>
           )}
-        {/* Quickfix: Show list collection map on page for Bremen */}
-        {showDescription && municipality && municipality.ags === '04011000' && (
-          <>
-            <h2 className={s.collectionMapHeadline}>Vor Ort unterschreiben</h2>
-            <p>
-              Hier findest du Orte in Bremen und Bremerhaven, an denen unsere
-              Listen ausliegen. Komm einfach vorbei und unterschreibe vor Ort!
-            </p>
-            <Map
-              mapConfig={{
-                state: 'bremen',
-                config: {
-                  center: [8.8108603, 53.0782442],
-                  zoom: 11,
-                },
-              }}
-            />
-            <Map
-              mapConfig={{
-                state: 'bremen',
-                config: {
-                  center: [8.6069175, 53.5480746],
-                  zoom: 11,
-                },
-              }}
-            />
-          </>
-        )}
         {/* all other municipalities */}
         {showDescription &&
           municipality &&

--- a/src/components/StaticPage/index.js
+++ b/src/components/StaticPage/index.js
@@ -267,6 +267,23 @@ export const pageQuery = graphql`
                 }
                 fullWidthOnDesktop
               }
+              ... on ContentfulSectionComponentCollectionMap {
+                __typename
+                showForOptions
+                column
+                maps {
+                  name
+                  state
+                  config {
+                    maxBounds
+                    zoom
+                    center
+                  }
+                }
+                text {
+                  json
+                }
+              }
             }
           }
           ... on ContentfulPageSectionDonation {


### PR DESCRIPTION
Resolves: https://expedition-grundeinkommen.monday.com/boards/853311751/pulses/1223585208

Rewrote the entire thing. Instead of the hack a section component is included on the municipality page. There was already an existing prototype for a collection map for the municipality page (https://app.contentful.com/spaces/af08tobnb0cl/content_types/sectionComponentCollectionMap/fields).  I just changed it a bit and added the queries etc. The benefit now is that we can easily add collection maps via contentful to the municipality page and use the flags to define when to show them. Might soon be helpful for Berlin for example. 

To test:
Check the maps in different states (Bremen page, other pages, signed in, signed out, /gemeinden page, via homepage, etc). Thanks!  

