### PR TITLE
Rewrote passwordless sign in

### DIFF
--- a/src/components/Login/EnterLoginCode/index.js
+++ b/src/components/Login/EnterLoginCode/index.js
@@ -129,17 +129,17 @@ export const EnterLoginCode = ({
       {answerChallengeState === 'wrongCode' && (
         <p>
           Der eingegebene Code ist falsch oder bereits abgelaufen. Bitte
-          überprüfe die Email erneut oder lade die Seite neu.
+          überprüfe die Email erneut oder fordere unten einen neuen Code an.
         </p>
       )}
 
       {(answerChallengeState === 'resentCode' ||
         answerChallengeState === 'restartSignIn') && (
-          <p>
-            Der Code wurde erneut per E-Mail {tempEmail ? ` (${tempEmail})` : ''}{' '}
+        <p>
+          Der Code wurde erneut per E-Mail {tempEmail ? ` (${tempEmail})` : ''}{' '}
           geschickt.
-          </p>
-        )}
+        </p>
+      )}
 
       {!answerChallengeState && (
         <>
@@ -150,8 +150,9 @@ export const EnterLoginCode = ({
               <h3>Schön, dass du an Bord bist.</h3>
               <p>
                 Um dich zu identifizieren, haben wir dir einen Code per E-Mail
-                  {tempEmail ? ` (${tempEmail})` : ''} geschickt.
-                  <br /><b>Dein Code ist drei Minuten lang gültig. </b>
+                {tempEmail ? ` (${tempEmail})` : ''} geschickt.
+                <br />
+                <b>Dein Code ist 20 Minuten lang gültig. </b>
               </p>
             </>
           )}{' '}
@@ -185,22 +186,27 @@ export const EnterLoginCode = ({
                   <CTAButton type="submit">
                     {buttonText ? buttonText : 'Abschicken'}
                   </CTAButton>
-                  {timerCounter === 0 ? <InlineButton
-                    type="button"
-                    onClick={() => {
-                      setAnswerChallengeState(undefined);
-                      setCode('resendCode');
-                      setTriggerOneMinuteTimer(triggerMinuteTimer + 1);
-                    }}
-                  >
-                    Code erneut senden
-                  </InlineButton> :
+                  {timerCounter === 0 ? (
+                    <InlineButton
+                      type="button"
+                      onClick={() => {
+                        setAnswerChallengeState(undefined);
+                        setCode('resendCode');
+                        setTriggerOneMinuteTimer(triggerMinuteTimer + 1);
+                      }}
+                    >
+                      Code erneut senden
+                    </InlineButton>
+                  ) : (
                     <div className={s.counterDescriptionContainer}>
                       <p className={s.counterDescription}>
-                        Wenn du den Code nicht erhalten hast, kannst du in {timerCounter} {timerCounter !== 1 ? 'Sekunden' : 'Sekunde'}{' '}
-                        den Code erneut anfordern.
+                        Wenn du den Code nicht erhalten hast, kannst du in{' '}
+                        {timerCounter}{' '}
+                        {timerCounter !== 1 ? 'Sekunden' : 'Sekunde'} den Code
+                        erneut anfordern.
                       </p>
-                    </div>}
+                    </div>
+                  )}
                 </CTAButtonContainer>
               </form>
             </FormWrapper>

--- a/src/hooks/Authentication/AnswerChallenge/index.js
+++ b/src/hooks/Authentication/AnswerChallenge/index.js
@@ -19,7 +19,7 @@ export const useAnswerChallenge = () => {
 const answerCustomChallenge = async (
   answer,
   setState,
-  { cognitoUser, setCognitoUser, setIsAuthenticated }
+  { tempEmail, setCognitoUser }
 ) => {
   // Send the answer to the User Pool
   try {
@@ -28,8 +28,14 @@ const answerCustomChallenge = async (
       /* webpackChunkName: "Amplify" */ '@aws-amplify/auth'
     );
 
+    // We call the signIn function of Amplify to then immediately send the challenge answer.
+    // The email with the code has already been sent via the /sign-in endpoint, so this function basically
+    // just initializes the custom flow without doing much (the backend function just gets the login code from the cognito user
+    // and sets it as the expected answer)
+    const user = await Auth.signIn(tempEmail);
+
     // sendCustomChallengeAnswer() will throw an error if it’s the 3rd wrong answer
-    const tempUser = await Auth.sendCustomChallengeAnswer(cognitoUser, answer);
+    const tempUser = await Auth.sendCustomChallengeAnswer(user, answer);
 
     if (answer === 'resendCode') {
       setState('resentCode');

--- a/src/hooks/Authentication/index.js
+++ b/src/hooks/Authentication/index.js
@@ -8,6 +8,7 @@ import querystring from 'query-string';
 import { navigate } from '@reach/router';
 import AuthContext from '../../context/Authentication';
 import { createUser } from '../Api/Users/Create';
+import CONFIG from '../../../aws-config';
 export { useAnswerChallenge } from './AnswerChallenge';
 export { useVerification } from './Verification';
 export { useLocalStorageUser } from './LocalStorageUser';
@@ -43,7 +44,7 @@ export const useSignIn = () => {
           setState('success');
         })
         .catch(error => {
-          if (error.code === 'UserNotFoundException') {
+          if (error.message === 'UserNotFoundException') {
             setState('userNotFound');
           } else {
             setState('error');
@@ -132,22 +133,33 @@ const signUp = async (data, { setUserId }) => {
   setUserId(userId);
 };
 
-// Sign in user through AWS Cognito (passwordless)
-const signIn = async ({ email }, { setCognitoUser, userId }) => {
-  const { default: Auth } = await import(
-    /* webpackChunkName: "Amplify" */ '@aws-amplify/auth'
+// Sign in user through api endpoint
+const signIn = async ({ email }, { setTempEmail }) => {
+  const request = {
+    method: 'POST',
+    mode: 'cors',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ email }),
+  };
+
+  const response = await fetch(
+    `${CONFIG.API.INVOKE_URL}/users/sign-in`,
+    request
   );
 
-  // If no email was passed we use the userId from context
-  const param = email ? email.toLowerCase() : userId;
+  if (response.status === 500) {
+    throw new Error('InternalServerException');
+  }
 
-  // This will initiate the custom flow, which will lead to the user receiving a mail.
-  // The code will timeout after 3 minutes (enforced server side by AWS Cognito).
-  const user = await Auth.signIn(param);
+  if (response.status === 404) {
+    throw new Error('UserNotFoundException');
+  }
 
-  // We already set the user here in the global context,
-  // because we need the object in answerCustomChallenge()
-  setCognitoUser(user);
+  // We need the temp mail later in the answe challenge function when we call
+  // the actual signIn function of Amplify
+  setTempEmail(email);
 };
 
 //Function, which uses the amplify api to sign out user


### PR DESCRIPTION
Resolves: https://expedition-grundeinkommen.monday.com/boards/853311751/pulses/1264619042

The backend was rewritten and now uses a separate /users/sign-in endpoint, which creates a new login code, saves it in the cognito record and then emails it to the user. Therefore in the frontend the whole order of steps is skewed. 

Old: 
1) Show Email Form
2) Call Auth.signIn() 
3) Show Login Code Form
4) Call Auth.sendCustomChallengeAnswer()

New:
1) Show Email Form
2) Call /users/sign-in endpoint
3) Show Login Code Form
4) Call Auth.signIn(), which does not do a lot except for initializing the Cognito Flow
5) Call Auth.sendCustomChallengeAnswer()

The new Code is heavily influenced by https://tschoffelen.medium.com/serverless-magic-links-with-aws-cognito-92eff1351123. A lot of the code is basically just copied (especially in the backend). 

The login code is now valid for twenty minutes, but this can easily be changed to a different value. 

To test:
- Sign in with existing user
- Sign in with a user which does not exist
- Sign up with existing user
- Sign up with new user

(Not all of the changed code actually changed, only the format changed, we really need to take care of the prettier config mismatch :D) 