### PR TITLE
Workaround for anchors not working on page load

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -12,3 +12,46 @@ if (location.host.indexOf('localhost') !== 0) {
     application: 'expedition-grundeinkommen',
   });
 }
+
+// Workaroud for hashes not working (https://github.com/gatsbyjs/gatsby/issues/386#issuecomment-249463446)
+export const onRouteUpdate = ({ location }) => {
+  jumpToHash(location.hash);
+};
+
+// We check every x ms if the element of the hash exists and then scroll to it.
+// This is useful for slow internet.
+const jumpToHash = hash => {
+  if (hash) {
+    waitForElementToDisplay(
+      hash,
+      element => {
+        element.scrollIntoView();
+      },
+      800,
+      15000
+    );
+  }
+};
+
+// Function to wait for the display of an element
+const waitForElementToDisplay = (
+  selector,
+  callback,
+  checkFrequencyInMs,
+  timeoutInMs
+) => {
+  var startTimeInMs = Date.now();
+  (function loopSearch() {
+    const element = document.querySelector(selector);
+    console.log('element', element);
+    if (element !== null) {
+      callback(element);
+      return;
+    } else {
+      setTimeout(function() {
+        if (timeoutInMs && Date.now() - startTimeInMs > timeoutInMs) return;
+        loopSearch();
+      }, checkFrequencyInMs);
+    }
+  })();
+};


### PR DESCRIPTION
Resolves: https://expedition-grundeinkommen.monday.com/boards/853311751/pulses/1096333332?userId=17160996

I added a function which runs on page load (and every time the route changes). It gets the hash from the url, looks for the id in the dom (multiple times every x ms, if internet is too slow) and then jumps to it. 

To test: check on multiple pages with anchors. E.g. /#map, /material#gesetzestexte, /presse/#pressespiegel and so on and so forth.
