### PR TITLE
Search places suggestion navigation via keyboard

### DIFF
--- a/src/components/Forms/SearchPlaces/index.js
+++ b/src/components/Forms/SearchPlaces/index.js
@@ -42,7 +42,7 @@ export const SearchPlaces = ({
   const [suggestionsActive, setSuggestionsActive] = useState(false);
   const [formState, setFormState] = useState({});
   const [fuse, setFuse] = useState();
-  const [focusedResult, setFocusedResult] = useState(0);
+  const [focusedResult, setFocusedResult] = useState();
 
   useEffect(() => {
     import('./municipalitiesForSearch.json').then(({ default: places }) => {
@@ -232,35 +232,34 @@ export const SearchPlaces = ({
   };
 
   const handleArrowListNavigation = e => {
-    const upBehavior =
-      e.key === 'ArrowUp' ||
-      e.which === 38 ||
-      ((e.key === 'Tab' || e.which === 9) && e.shiftKey);
-    const downBehavior =
-      e.key === 'ArrowDown' ||
-      e.which === 40 ||
-      ((e.key === 'Tab' || e.which === 9) && !e.shiftKey);
+    const isTab = e.key === 'Tab' || e.which === 9;
 
-    if (upBehavior || downBehavior) {
-      e.preventDefault();
-    }
+    const upBehavior =
+      e.key === 'ArrowUp' || e.which === 38 || (isTab && e.shiftKey);
+    const downBehavior =
+      e.key === 'ArrowDown' || e.which === 40 || (isTab && !e.shiftKey);
 
     if (downBehavior) {
       // At the end of a list jump back to the beginning
-      // and vice versa
+      // and vice versa (but only for arrow keys).
+      // If at the end and tab is pressed we want default behaviour
       if (
         focusedResult < results.length - 1 &&
         typeof focusedResult !== 'undefined'
       ) {
         setFocusedResult(prev => prev + 1);
-      } else {
+        e.preventDefault();
+      } else if (!isTab) {
         setFocusedResult(0);
+        e.preventDefault();
       }
     } else if (upBehavior) {
       if (focusedResult > 0 && focusedResult < results.length) {
         setFocusedResult(prev => prev - 1);
-      } else {
+        e.preventDefault();
+      } else if (!isTab) {
         setFocusedResult(results.length - 1);
+        e.preventDefault();
       }
     }
   };
@@ -270,7 +269,12 @@ export const SearchPlaces = ({
       e.relatedTarget &&
       [...e.relatedTarget.classList].join('').includes('suggestionsItem');
 
-    if (!isAutoCompleteTarget) {
+    const isAutoCompleteContainerTarget =
+      e.relatedTarget &&
+      [...e.relatedTarget.classList].join('').includes('suggestions') &&
+      ![...e.relatedTarget.classList].join('').includes('suggestionsItem');
+
+    if (!isAutoCompleteTarget && !isAutoCompleteContainerTarget) {
       setTimeout(() => {
         setSuggestionsActive(false);
 
@@ -286,6 +290,9 @@ export const SearchPlaces = ({
           validate();
         }
       }, 300);
+    }
+
+    if (isAutoCompleteContainerTarget) {
       setFocusedResult(0);
     }
   };
@@ -305,7 +312,11 @@ export const SearchPlaces = ({
             onChange={handleChange}
             onKeyDown={handleEnterKey}
             onBlur={handleBlur}
-            className={cN(s.searchBar, { [s.isNotInsideForm]: !isInsideForm }, { [s.fullWidthInput]: fullWidthInput })}
+            className={cN(
+              s.searchBar,
+              { [s.isNotInsideForm]: !isInsideForm },
+              { [s.fullWidthInput]: fullWidthInput }
+            )}
           />
 
           <AutoCompleteList
@@ -362,9 +373,9 @@ export function AutoCompleteList({
 
   return (
     <div
-      aria-hidden={true}
       className={cN(s.suggestions, { [s.active]: suggestionsActive })}
       onBlur={handleBlur}
+      role="listbox"
     >
       {results.length === 0 && query.length > 1 && (
         <div className={s.noSuggestionsItem}>Keine Ergebnisse</div>

--- a/src/components/Forms/SearchPlaces/index.js
+++ b/src/components/Forms/SearchPlaces/index.js
@@ -42,7 +42,7 @@ export const SearchPlaces = ({
   const [suggestionsActive, setSuggestionsActive] = useState(false);
   const [formState, setFormState] = useState({});
   const [fuse, setFuse] = useState();
-  const [focusedResult, setFocusedResult] = useState();
+  const [focusedResult, setFocusedResult] = useState(null);
 
   useEffect(() => {
     import('./municipalitiesForSearch.json').then(({ default: places }) => {
@@ -225,9 +225,14 @@ export const SearchPlaces = ({
   };
 
   const handleEnterKey = e => {
-    // Emulate click when enter or space are pressed
+    // Emulate click when enter is pressed
     if (e.key === 'Enter') {
       handleSuggestionClick(results[0]);
+    }
+
+    // Focus into suggestions when pressing arrow down
+    if (e.key === 'ArrowDown' || e.which === 40) {
+      setFocusedResult(0);
     }
   };
 
@@ -243,10 +248,7 @@ export const SearchPlaces = ({
       // At the end of a list jump back to the beginning
       // and vice versa (but only for arrow keys).
       // If at the end and tab is pressed we want default behaviour
-      if (
-        focusedResult < results.length - 1 &&
-        typeof focusedResult !== 'undefined'
-      ) {
+      if (focusedResult < results.length - 1 && focusedResult !== null) {
         setFocusedResult(prev => prev + 1);
         e.preventDefault();
       } else if (!isTab) {
@@ -277,6 +279,7 @@ export const SearchPlaces = ({
     if (!isAutoCompleteTarget && !isAutoCompleteContainerTarget) {
       setTimeout(() => {
         setSuggestionsActive(false);
+        setFocusedResult(null);
 
         // If search places input is inside form,
         // we want to choose first element of suggestions as place
@@ -363,10 +366,7 @@ export function AutoCompleteList({
   }, [results]);
 
   useLayoutEffect(() => {
-    if (
-      typeof focusedResult !== 'undefined' &&
-      focusedResult < resultsRef.current.length
-    ) {
+    if (focusedResult !== null && focusedResult < resultsRef.current.length) {
       resultsRef.current[focusedResult].focus();
     }
   }, [focusedResult, resultsRef]);


### PR DESCRIPTION
Kinda part of this issue: https://expedition-grundeinkommen.monday.com/boards/853311751/pulses/1264623669

1) Fixed broken navigation through suggestions in Firefox. 
2) Focus into suggestions when pressing keydown while focused on input field.
3) When tabbing through suggestions, leave suggestion container after last result so there is a way to tab through form without being trapped in suggestions container. 

I don't have Safari, so maybe also check in Safari, since there seem to be differences in various browsers. 