### PR TITLE
Gemeinden to orte

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -110,13 +110,13 @@ exports.createPages = ({ graphql, actions }) => {
       }
     } else {
       createPage({
-        path: `/gemeinden/${municipality.slug}`,
+        path: `/orte/${municipality.slug}`,
         component: require.resolve('./src/components/StaticPage/index.js'),
         context: {
           municipality: { ...municipality },
           isMunicipality: true,
           isSpecificMunicipality: true,
-          slug: 'gemeinden',
+          slug: 'orte',
         },
       });
     }
@@ -166,7 +166,7 @@ exports.createPages = ({ graphql, actions }) => {
             return;
           }
           const path = page.node.slug === '/' ? '/' : `/${page.node.slug}/`;
-          const isMunicipality = page.node.slug === 'gemeinden';
+          const isMunicipality = page.node.slug === 'orte';
           createPage({
             path: path,
             component: staticPage,

--- a/src/components/Forms/SearchPlaces/index.js
+++ b/src/components/Forms/SearchPlaces/index.js
@@ -189,11 +189,11 @@ export const SearchPlaces = ({
   const validate = () => {
     let slug;
     if (selectedPlace.ags) {
-      slug = `/gemeinden/${selectedPlace.slug}`;
+      slug = `/orte/${selectedPlace.slug}`;
       return { status: 'success', slug };
     }
     if (results.length > 0 && results[0].score < 0.001) {
-      slug = `/gemeinden/${results[0].slug}`;
+      slug = `/orte/${results[0].slug}`;
       return { status: 'success', slug };
     }
     const touched = true;

--- a/src/components/Layout/index.js
+++ b/src/components/Layout/index.js
@@ -245,7 +245,7 @@ function Template({ children, sections, pageContext, title, description }) {
       sortedMunicipalities.slice(0, num).forEach(item => {
         menuItems.push({
           title: `Mein Ort: ${item.name}`,
-          slug: `gemeinden/${item.slug}`,
+          slug: `orte/${item.slug}`,
           shortTitle: null,
         });
       });

--- a/src/components/Municipality/MapAndSearch/MunicipalityMoreDetails.jsx
+++ b/src/components/Municipality/MapAndSearch/MunicipalityMoreDetails.jsx
@@ -38,7 +38,7 @@ export const MunicipalityMoreDetails = ({
         <div className={s.buttonContainer}>
           <Button
             className={s.municipalityButton}
-            onClick={() => navigate(`/gemeinden/${municipalityToDisplay.slug}`)}
+            onClick={() => navigate(`/orte/${municipalityToDisplay.slug}`)}
           >
             Zur Ortsseite
           </Button>

--- a/src/components/Municipality/MunicipalityIntro/index.js
+++ b/src/components/Municipality/MunicipalityIntro/index.js
@@ -61,8 +61,8 @@ const ColumnQualifying = ({
               {municipalityStats.signups === 1
                 ? 'eine Anmeldung '
                 : `${municipalityStats.signups?.toLocaleString(
-                  'de'
-                )} Anmeldungen `}
+                    'de'
+                  )} Anmeldungen `}
               {municipality ? `in ${municipality.name}` : ''}!{' '}
             </p>
           ) : (
@@ -210,9 +210,9 @@ export const MunicipalityIntro = ({ pageContext, className, title, body }) => {
       }
     } else {
       const { slug } = pageContext;
-      if (slug === 'gemeinden') {
+      if (slug === 'orte') {
         setType('qualifying');
-      } else if (slug === 'gemeinden-sammelphase') {
+      } else if (slug === 'orte-sammelphase') {
         setType('collecting');
       } else {
         setType('state');
@@ -277,7 +277,7 @@ export const MunicipalityIntro = ({ pageContext, className, title, body }) => {
     }
     return () => {
       if (typeof window !== `undefined`) {
-        window.onpopstate = () => { };
+        window.onpopstate = () => {};
       }
     };
   }, [municipality]);
@@ -302,7 +302,7 @@ export const MunicipalityIntro = ({ pageContext, className, title, body }) => {
   //           window.history.pushState(
   //             selected,
   //             null,
-  //             `${window.location.origin}/gemeinden/${selected.ags}`
+  //             `${window.location.origin}/orte/${selected.ags}`
   //           );
   //           adjustDocumentTitle(municipality, selected.name);
   //           setWindowLocationOriginForIE();

--- a/src/components/Municipality/MunicipalityMap/index.js
+++ b/src/components/Municipality/MunicipalityMap/index.js
@@ -473,7 +473,7 @@ const flyTo = ({
 };
 
 const goToMunicipalityPage = info => {
-  navigate(`/gemeinden/${info.object.slug}`);
+  navigate(`/orte/${info.object.slug}`);
 };
 
 const Map = ({

--- a/src/components/Onboarding/FinalNote/index.js
+++ b/src/components/Onboarding/FinalNote/index.js
@@ -39,7 +39,7 @@ export const FinalNote = ({
         className={s.redirectButton}
         onClick={() => {
           setCurrentElementByIndex(compIndex + 1);
-          navigate(`/gemeinden/${municipality.slug}`);
+          navigate(`/orte/${municipality.slug}`);
         }}
       >
         Zur Unterseite

--- a/src/context/utils/index.js
+++ b/src/context/utils/index.js
@@ -44,7 +44,7 @@ history.pushToHistoryState = (municipality, pageContext) => {
       window.history.pushState(
         { municipality, pageContext },
         null,
-        `${window.location.origin}/gemeinden/${municipality.slug}`
+        `${window.location.origin}/orte/${municipality.slug}`
       );
       adjustDocumentTitle(municipality, municipality.name);
       setWindowLocationOriginForIE();

--- a/static/_redirects
+++ b/static/_redirects
@@ -6,7 +6,8 @@ https://expedition-grundeinkommen.de/gemeinde-teilen/*  https://ag5gu1z06h.execu
 /gemeinde-teilen/*  https://2j0bcp5tr9.execute-api.eu-central-1.amazonaws.com/dev/share-municipality/:splat 200
 /downloads                                      /material
 /Briefkasten                                    /briefkasten
-/berlin                                         /gemeinden/berlin
-/hamburg                                        /gemeinden/hamburg
-/bremen                                         /gemeinden/bremen
+/berlin                                         /orte/berlin
+/hamburg                                        /orte/hamburg
+/bremen                                         /orte/bremen
+/gemeinden/*                                    /orte/:splat
 /teilen/:userId                                 /teilen/?userId=:userId


### PR DESCRIPTION
Resolves: https://expedition-grundeinkommen.monday.com/boards/853311751/pulses/1697083741

1) I changed all occurences of the gemeinden slug to orte
2) I changed the existing redirects (such as /berlin) and added a new redirect /gemeinden to /orte

To test: 
- check all spots, where links to municipality pages occur (such as in the leaderboard, in the menu, etc) 
- check redirects