### PR TITLE
List public collection events by day

### DIFF
--- a/src/components/Forms/Meetup/index.js
+++ b/src/components/Forms/Meetup/index.js
@@ -170,29 +170,33 @@ export const CreateMeetup = ({
                       className={s.formSection}
                       fieldContainerClassName={s.inlineFieldSection}
                     >
-                      <p className={s.eventText}>Du planst ein Event am:</p>
-                      <Field
-                        name="date"
-                        label="Datum"
-                        component={DateInputWrapped}
-                        customRef={dateInputEl}
-                      ></Field>
-                      <div className={s.timeInputRow}>
-                        <div className={s.timeInput}>
-                          <p className={s.eventText}>von:</p>
+                      <div className={s.formContainer}>
+                        <div className={s.dateInputRow}>
+                          <p className={s.eventText}>Du planst ein Event am:</p>
                           <Field
-                            name="start"
-                            label="Start"
-                            component={TimeInputWrapped}
+                            name="date"
+                            label="Datum"
+                            component={DateInputWrapped}
+                            customRef={dateInputEl}
                           ></Field>
                         </div>
-                        <div className={s.timeInput}>
-                          <p className={s.eventText}>bis:</p>
-                          <Field
-                            name="end"
-                            label="Ende"
-                            component={TimeInputWrapped}
-                          ></Field>
+                        <div className={s.timeInputRow}>
+                          <div className={s.timeInput}>
+                            <p className={s.eventText}>von:</p>
+                            <Field
+                              name="start"
+                              label="Start"
+                              component={TimeInputWrapped}
+                            ></Field>
+                          </div>
+                          <div className={s.timeInput}>
+                            <p className={s.eventText}>bis:</p>
+                            <Field
+                              name="end"
+                              label="Ende"
+                              component={TimeInputWrapped}
+                            ></Field>
+                          </div>
                         </div>
                       </div>
                     </FormSection>

--- a/src/components/Forms/Meetup/index.js
+++ b/src/components/Forms/Meetup/index.js
@@ -129,8 +129,8 @@ export const CreateMeetup = ({
       {location && (
         <>
           <p className={s.chosenLocation}>
-            <span className={s.coloredText}>Gewählter Ort: </span>
-            {location.place_name_de}
+            <span className={s.coloredText}>Gewählter Ort:</span>
+            <span className={s.placeName}>{location.place_name}</span>
           </p>
 
           <Form
@@ -170,27 +170,31 @@ export const CreateMeetup = ({
                       className={s.formSection}
                       fieldContainerClassName={s.inlineFieldSection}
                     >
-                      <span className={s.eventText}>
-                        Du planst ein Event am
-                      </span>
+                      <p className={s.eventText}>Du planst ein Event am:</p>
                       <Field
                         name="date"
                         label="Datum"
                         component={DateInputWrapped}
                         customRef={dateInputEl}
                       ></Field>
-                      <span className={s.eventText}>von</span>
-                      <Field
-                        name="start"
-                        label="Start"
-                        component={TimeInputWrapped}
-                      ></Field>
-                      <span className={s.eventText}>bis</span>
-                      <Field
-                        name="end"
-                        label="Ende"
-                        component={TimeInputWrapped}
-                      ></Field>
+                      <div className={s.timeInputRow}>
+                        <div className={s.timeInput}>
+                          <p className={s.eventText}>von:</p>
+                          <Field
+                            name="start"
+                            label="Start"
+                            component={TimeInputWrapped}
+                          ></Field>
+                        </div>
+                        <div className={s.timeInput}>
+                          <p className={s.eventText}>bis:</p>
+                          <Field
+                            name="end"
+                            label="Ende"
+                            component={TimeInputWrapped}
+                          ></Field>
+                        </div>
+                      </div>
                     </FormSection>
                   )}
                   {type === 'lists' && (

--- a/src/components/Forms/Meetup/style.module.less
+++ b/src/components/Forms/Meetup/style.module.less
@@ -22,6 +22,7 @@
 
 .chosenLocation {
   font-weight: bold;
+  margin-bottom: 0.5rem;
 }
 
 .coloredText {
@@ -30,6 +31,11 @@
 
 .formSection {
   margin-bottom: 0;
+}
+
+.formContainer {
+  display: flex;
+  flex-wrap: wrap;
 }
 
 .inlineFieldSection {
@@ -52,10 +58,17 @@
 
 .timeInputRow {
   display: flex;
+  flex-wrap: wrap;
+}
+
+.dateInputRow {
+  margin-top: 0.5rem;
+  margin-right: 0.5rem;
 }
 
 .timeInput {
-  margin-right: 1rem;
+  margin-right: 0.5rem;
+  margin-top: 0.5rem;
 }
 
 .textarea {

--- a/src/components/Forms/Meetup/style.module.less
+++ b/src/components/Forms/Meetup/style.module.less
@@ -36,19 +36,26 @@
   display: flex;
   width: 100%;
   justify-content: space-between;
-
-  @media (max-width: @breakPointM) {
-    flex-direction: column;
-  }
+  flex-direction: column;
+  margin-bottom: 2rem;
 }
 
 .eventText {
-  padding-top: 2.5rem;
   font-size: @DesktopFontSizeM;
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+}
 
-  @media (max-width: @breakPointM) {
-    padding-top: 0;
-  }
+.placeName {
+  margin-left: 0.5rem;
+}
+
+.timeInputRow {
+  display: flex;
+}
+
+.timeInput {
+  margin-right: 1rem;
 }
 
 .textarea {

--- a/src/components/Maps/EventsListed.js
+++ b/src/components/Maps/EventsListed.js
@@ -1,52 +1,59 @@
 import React from 'react';
+import * as s from './style.module.less';
+import * as dsm from './utils/dateStringManipulation';
 
 export const EventsListed = ({ locationsFiltered }) => {
-  const locationsSorted = locationsFiltered
-    ?.filter(location => location.startTime && location.endTime)
-    .sort(function (a, b) {
-      return new Date(a.startTime) - new Date(b.startTime);
-    });
+  let groupedEvents = {};
+  let locationsSorted = [];
 
   const groupByDate = locations => {
-    const groupedEvents = {};
-
     locations.forEach(location => {
-      if (!(location.startTime in groupedEvents)) {
-        groupedEvents[location.startTime] = [];
-        groupedEvents[location.startTime].push(location);
+      const eventDate = dsm.getGermanDateFormat(location.startTime);
+      if (!(eventDate in groupedEvents)) {
+        groupedEvents[eventDate] = [];
+        groupedEvents[eventDate].push(location);
       } else {
-        groupedEvents[location.startTime].push(location);
+        groupedEvents[eventDate].push(location);
       }
     });
   };
 
-  if (locationsSorted) {
-    const groupedEvents = groupByDate(locationsSorted);
-    console.log(groupedEvents);
+  if (locationsFiltered) {
+    locationsSorted = locationsFiltered
+      ?.filter(location => location.startTime && location.endTime)
+      .sort(function (a, b) {
+        return new Date(a.startTime) - new Date(b.startTime);
+      });
+    groupByDate(locationsSorted);
   }
 
   return (
-    <div>
-      <h2>Komm zu einer Sammelaktion</h2>
-      {locationsSorted?.map((location, index) => {
-        return (
-          <div key={index}>
-            <p>{location.address}</p>
-            <p>{`${new Date(location.startTime).toLocaleDateString(
-              'de-DE'
-            )} ${new Date(location.startTime).toLocaleTimeString('de-DE', {
-              hour: '2-digit',
-              minute: '2-digit',
-            })}`}</p>
-            <p>{`${new Date(location.endTime).toLocaleDateString(
-              'de-DE'
-            )} ${new Date(location.endTime).toLocaleTimeString('de-DE', {
-              hour: '2-digit',
-              minute: '2-digit',
-            })}`}</p>
-          </div>
-        );
-      })}
-    </div>
+    <>
+      <h2 className={s.moduleHeading}>Komm zu einer Sammelaktion</h2>
+      <div className={s.eventContainer}>
+        {Object.keys(groupedEvents).map(key => {
+          return (
+            <div key={key} className={s.eventDay}>
+              <h3 className={s.descriptionHeading}>
+                {dsm.getDateWithWeekday(groupedEvents[key][0].startTime)}
+              </h3>
+              {groupedEvents[key].map(event => {
+                return (
+                  <div className={s.eventDescription}>
+                    <p className={s.descriptionText}>{event.description}</p>
+                    <b>
+                      {dsm.localeTime(event.startTime)}-
+                      {dsm.localeTime(event.endTime)}
+                      {' Uhr, '}
+                      {event.address}
+                    </b>
+                  </div>
+                );
+              })}
+            </div>
+          );
+        })}
+      </div>
+    </>
   );
 };

--- a/src/components/Maps/EventsListed.js
+++ b/src/components/Maps/EventsListed.js
@@ -9,12 +9,8 @@ export const EventsListed = ({ locationsFiltered }) => {
   const groupByDate = locations => {
     locations.forEach(location => {
       const eventDate = dsm.getGermanDateFormat(location.startTime);
-      if (!(eventDate in groupedEvents)) {
-        groupedEvents[eventDate] = [];
-        groupedEvents[eventDate].push(location);
-      } else {
-        groupedEvents[eventDate].push(location);
-      }
+      if (!(eventDate in groupedEvents)) groupedEvents[eventDate] = [];
+      groupedEvents[eventDate].push(location);
     });
   };
 

--- a/src/components/Maps/LazyMap.js
+++ b/src/components/Maps/LazyMap.js
@@ -103,10 +103,10 @@ const lazyMap = ({
           'top-left'
         );
 
-        console.log([
-          ...mapboxConfig.maxBounds[0],
-          ...mapboxConfig.maxBounds[1],
-        ]);
+        // console.log([
+        //   ...mapboxConfig.maxBounds[0],
+        //   ...mapboxConfig.maxBounds[1],
+        // ]);
 
         if (withSearch) {
           // Initialize geo coder

--- a/src/components/Maps/ShowMeetups.js
+++ b/src/components/Maps/ShowMeetups.js
@@ -9,7 +9,7 @@ import {
 import { Button } from '../Forms/Button';
 import { MeetupOverlayContext } from '../../context/Overlay/MeetupOverlay';
 import * as s from './style.module.less';
-// import { EventsListed } from './EventsListed';
+import { EventsListed } from './EventsListed';
 
 export const ShowMeetups = ({ mapConfig, className }) => {
   const {
@@ -151,9 +151,9 @@ export const ShowMeetups = ({ mapConfig, className }) => {
               </Button>
             </SectionComponent>
           </SectionComponentContainer>
-          {/* <br />
           <br />
-          <EventsListed locationsFiltered={locationsFiltered} /> */}
+          <br />
+          <EventsListed locationsFiltered={locationsFiltered} />
         </div>
       )}
     </>

--- a/src/components/Maps/ShowMeetups.js
+++ b/src/components/Maps/ShowMeetups.js
@@ -151,8 +151,6 @@ export const ShowMeetups = ({ mapConfig, className }) => {
               </Button>
             </SectionComponent>
           </SectionComponentContainer>
-          <br />
-          <br />
           <EventsListed locationsFiltered={locationsFiltered} />
         </div>
       )}

--- a/src/components/Maps/style.module.less
+++ b/src/components/Maps/style.module.less
@@ -222,6 +222,12 @@ h3 {
   flex: 50%;
   min-width: 50%;
   max-width: 50%;
+
+  @media (max-width: @breakPointL) {
+    flex: 100%;
+    min-width: 100%;
+    max-width: 100%;
+  }
 }
 
 .moduleHeading {
@@ -229,21 +235,37 @@ h3 {
   margin-bottom: 4rem;
   color: @violet;
   font-size: @DesktopFontSizeXL;
+
+  @media (max-width: @breakPointM) {
+    font-size: @DesktopFontSizeL;
+  }
 }
 
 .descriptionHeading {
   margin: 0;
   color: @violet;
   font-size: 2.25rem;
+
+  @media (max-width: @breakPointM) {
+    font-size: @DesktopFontSizeM;
+  }
 }
 
 .eventDescription {
   margin-top: 1rem;
   margin-bottom: 3rem;
   font-size: 1.5rem;
+
+  @media (max-width: @breakPointM) {
+    font-size: 1rem;
+  }
 }
 
 .descriptionText {
   margin: 0;
   font-size: 1.5rem;
+
+  @media (max-width: @breakPointM) {
+    font-size: 1rem;
+  }
 }

--- a/src/components/Maps/style.module.less
+++ b/src/components/Maps/style.module.less
@@ -254,10 +254,12 @@ h3 {
 .eventDescription {
   margin-top: 1rem;
   margin-bottom: 3rem;
+  padding-right: 1rem;
   font-size: 1.5rem;
 
   @media (max-width: @breakPointM) {
     font-size: 1rem;
+    padding-right: 0rem;
   }
 }
 

--- a/src/components/Maps/style.module.less
+++ b/src/components/Maps/style.module.less
@@ -212,3 +212,38 @@ h3 {
     bottom: 0;
   }
 }
+
+.eventContainer {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.eventDay {
+  flex: 50%;
+  min-width: 50%;
+  max-width: 50%;
+}
+
+.moduleHeading {
+  margin-top: 6rem;
+  margin-bottom: 4rem;
+  color: @violet;
+  font-size: @DesktopFontSizeXL;
+}
+
+.descriptionHeading {
+  margin: 0;
+  color: @violet;
+  font-size: 2.25rem;
+}
+
+.eventDescription {
+  margin-top: 1rem;
+  margin-bottom: 3rem;
+  font-size: 1.5rem;
+}
+
+.descriptionText {
+  margin: 0;
+  font-size: 1.5rem;
+}

--- a/src/components/Maps/utils/dateStringManipulation.js
+++ b/src/components/Maps/utils/dateStringManipulation.js
@@ -28,7 +28,8 @@ export const localeTime = date => {
 };
 
 export const getDayWithMonth = date => {
-  return getGermanDateFormat(date).slice(0, 6);
+  const dateString = getGermanDateFormat(new Date(date)).split('.');
+  return `${dateString[0]}.${dateString[1]}.`;
 };
 
 export const checkIfDateIsToday = date => {

--- a/src/components/Maps/utils/dateStringManipulation.js
+++ b/src/components/Maps/utils/dateStringManipulation.js
@@ -1,23 +1,27 @@
+export const GER_LOCALE = 'de-DE';
+
 export const getGermanDateFormat = date => {
-  return new Date(date).toLocaleDateString('de-DE');
+  return new Date(date).toLocaleDateString(GER_LOCALE);
 };
 
 export const getDateWithWeekday = date => {
-  if (checkIfDateIsToday(date)) {
-    return checkIfDateIsToday(date);
-  } else if (checkIfDateIsTomorrow(date)) {
-    return checkIfDateIsTomorrow(date);
-  }
-  return `${getDayName(new Date(date))}, ${getDayWithMonth(date)}`;
+  const isToday = checkIfDateIsToday(date);
+  if (isToday) return 'Heute';
+
+  const isTomorrow = checkIfDateIsTomorrow(date);
+  if (isTomorrow) return 'Morgen';
+
+  const otherDay = `${getDayName(new Date(date))}, ${getDayWithMonth(date)}`;
+  return otherDay;
 };
 
-export const getDayName = (dateStr, locale = 'de-DE') => {
+export const getDayName = dateStr => {
   var date = new Date(dateStr);
-  return date.toLocaleDateString(locale, { weekday: 'long' });
+  return date.toLocaleDateString(GER_LOCALE, { weekday: 'long' });
 };
 
 export const localeTime = date => {
-  return new Date(date).toLocaleTimeString('de-DE', {
+  return new Date(date).toLocaleTimeString(GER_LOCALE, {
     hour: '2-digit',
     minute: '2-digit',
   });
@@ -27,21 +31,21 @@ export const getDayWithMonth = date => {
   return getGermanDateFormat(date).slice(0, 6);
 };
 
-const checkIfDateIsToday = date => {
+export const checkIfDateIsToday = date => {
   if (checkIfInRangeOfDaysX(date, 0)) {
-    return 'Heute';
+    return true;
   }
   return false;
 };
 
-const checkIfDateIsTomorrow = date => {
+export const checkIfDateIsTomorrow = date => {
   if (checkIfInRangeOfDaysX(date, 1)) {
-    return 'Morgen';
+    return true;
   }
   return false;
 };
 
-const checkIfInRangeOfDaysX = (dateStr, num) => {
+export const checkIfInRangeOfDaysX = (dateStr, num) => {
   const date = new Date(dateStr);
   const dateToCheck = new Date(
     date.getFullYear(),

--- a/src/components/Maps/utils/dateStringManipulation.js
+++ b/src/components/Maps/utils/dateStringManipulation.js
@@ -1,0 +1,65 @@
+export const getGermanDateFormat = date => {
+  return new Date(date).toLocaleDateString('de-DE');
+};
+
+export const getDateWithWeekday = date => {
+  if (checkIfDateIsToday(date)) {
+    return checkIfDateIsToday(date);
+  } else if (checkIfDateIsTomorrow(date)) {
+    return checkIfDateIsTomorrow(date);
+  }
+  return `${getDayName(new Date(date))}, ${getDayWithMonth(date)}`;
+};
+
+export const getDayName = (dateStr, locale = 'de-DE') => {
+  var date = new Date(dateStr);
+  return date.toLocaleDateString(locale, { weekday: 'long' });
+};
+
+export const localeTime = date => {
+  return new Date(date).toLocaleTimeString('de-DE', {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+};
+
+export const getDayWithMonth = date => {
+  return getGermanDateFormat(date).slice(0, 6);
+};
+
+const checkIfDateIsToday = date => {
+  if (checkIfInRangeOfDaysX(date, 0)) {
+    return 'Heute';
+  }
+  return false;
+};
+
+const checkIfDateIsTomorrow = date => {
+  if (checkIfInRangeOfDaysX(date, 1)) {
+    return 'Morgen';
+  }
+  return false;
+};
+
+const checkIfInRangeOfDaysX = (dateStr, num) => {
+  const date = new Date(dateStr);
+  const dateToCheck = new Date(
+    date.getFullYear(),
+    date.getMonth(),
+    date.getDate()
+  );
+  const dateToday = new Date();
+  const dateToCompare = new Date(
+    dateToday.getFullYear(),
+    dateToday.getMonth(),
+    dateToday.getDate() + num
+  );
+  if (
+    dateToCheck.getFullYear() === dateToCompare.getFullYear() &&
+    dateToCheck.getMonth() === dateToCompare.getMonth() &&
+    dateToCheck.getDate() === dateToCompare.getDate()
+  ) {
+    return true;
+  }
+  return false;
+};

--- a/src/components/Maps/utils/utils.spec.js
+++ b/src/components/Maps/utils/utils.spec.js
@@ -1,0 +1,79 @@
+import * as dsm from './dateStringManipulation';
+
+const germanWeekdays = [
+  'Montag',
+  'Dienstag',
+  'Mittwoch',
+  'Donnerstag',
+  'Freitag',
+  'Samstag',
+  'Sonntag',
+];
+
+describe('Date-String manipulation Utils', () => {
+  it('returns a dates name of the weekday', () => {
+    // Arrange & Act
+    const today = dsm.getDayName(new Date());
+    // Assert
+    const checkName = germanWeekdays.includes(today);
+    expect(checkName).toBe(true);
+  });
+
+  it('knows if a date is today or tomorrow', () => {
+    // Arrange
+    const baseDate = new Date();
+    const dateToday = new Date(
+      baseDate.getFullYear(),
+      baseDate.getMonth(),
+      baseDate.getDate(),
+      baseDate.getHours(),
+      baseDate.getMinutes() + 1
+    );
+    const dateTomorrow = new Date(
+      baseDate.getFullYear(),
+      baseDate.getMonth(),
+      baseDate.getDate() + 1
+    );
+    const dateOtherDay = new Date(
+      baseDate.getFullYear(),
+      baseDate.getMonth(),
+      baseDate.getDate() + 20
+    );
+
+    // Act
+    const todayDateToday = dsm.checkIfDateIsToday(dateToday);
+    const todayDateTomorrow = dsm.checkIfDateIsToday(dateTomorrow);
+    const tomorrowDateToday = dsm.checkIfDateIsTomorrow(dateToday);
+    const tomorrowDateTomorrow = dsm.checkIfDateIsTomorrow(dateTomorrow);
+    const otherDayDateToday = dsm.checkIfDateIsToday(dateOtherDay);
+    const otherDayDateTomorrow = dsm.checkIfDateIsTomorrow(dateOtherDay);
+
+    // Assert
+    expect(todayDateToday).toBe(true);
+    expect(todayDateTomorrow).toBe(false);
+    expect(tomorrowDateToday).toBe(false);
+    expect(tomorrowDateTomorrow).toBe(true);
+    expect(otherDayDateToday).toBe(false);
+    expect(otherDayDateTomorrow).toBe(false);
+  });
+
+  it('matches german date format', () => {
+    // Arrange
+    const dateRegEx =
+      /^\s*(3[01]|[12][0-9]|0?[1-9])\.(1[012]|0?[1-9])\.((?:19|20)\d{2})\s*$/;
+    // Act
+    const date = dsm.getGermanDateFormat(new Date());
+    // Assert
+    expect(date).toMatch(dateRegEx);
+  });
+
+  it('gets day and month from date', () => {
+    // Arrange
+    const baseDate = new Date();
+    const expectedString = `${baseDate.getDate()}.${baseDate.getMonth() + 1}.`;
+    // Act
+    const received = dsm.getDayWithMonth(new Date());
+    // Assert
+    expect(received).toBe(expectedString);
+  });
+});


### PR DESCRIPTION
This PR adds a list by day, of all collection events. To test, just look at `"/playground/karte"` and create an event, if not present, to see, if `"Heute"` and `"Morgen"` is correctly added as a label for events happening today and tomorrow.

Unfortunately it was not so easy to place the upcoming events in a two column layout, reading from top to bottom in the left column first, and the right column second. I would need to do some calculations to see how many events each day holds and group 50% of them into one group and the rest into another. This might make the logic even more complex. Let me know, if you can think of an easier way. :)