### PR TITLE
Packages: createdAt instead timestamp

### DIFF
--- a/src/components/PledgePackage/ListPledgePackages/index.js
+++ b/src/components/PledgePackage/ListPledgePackages/index.js
@@ -74,7 +74,7 @@ export default () => {
                   key={index}
                   body={pledgePackage.body}
                   user={userData}
-                  timestamp={pledgePackage.timestamp}
+                  timestamp={pledgePackage.createdAt}
                 />
               );
             })}
@@ -109,7 +109,7 @@ export default () => {
                   key={index}
                   body={pledgePackage.body}
                   user={pledgePackage.user}
-                  timestamp={pledgePackage.timestamp}
+                  timestamp={pledgePackage.createdAt}
                 />
               );
             })}


### PR DESCRIPTION
Due to backend changes I had to rename a key. 

See: https://github.com/grundeinkommensbuero/backend/pull/129