### PR TITLE
Sign up user for municipality after creating package

### DIFF
--- a/src/components/Forms/SignatureListDownload/index.js
+++ b/src/components/Forms/SignatureListDownload/index.js
@@ -4,13 +4,7 @@ import * as s from './style.module.less';
 
 import { Form, Field } from 'react-final-form';
 import { TextInputWrapped } from '../TextInput';
-import {
-  validateEmail,
-  addActionTrackingId,
-  trackEvent,
-  // mapCampaignCodeToAgs,
-  // mapCampaignCodeToState,
-} from '../../utils';
+import { validateEmail, addActionTrackingId, trackEvent } from '../../utils';
 import { CTAButton, CTAButtonContainer } from '../../Layout/CTAButton';
 import { LinkButton, InlineButton } from '../Button';
 import { FinallyMessage } from '../FinallyMessage';

--- a/src/components/PledgePackage/CreatePledgePackage/index.js
+++ b/src/components/PledgePackage/CreatePledgePackage/index.js
@@ -7,13 +7,16 @@ import { Button } from '../../Forms/Button';
 import { TextInputWrapped } from '../../Forms/TextInput';
 import { FinallyMessage } from '../../Forms/FinallyMessage';
 import { useSaveInteraction } from '../../../hooks/Api/Interactions';
+import { useUpdateUser } from '../../../hooks/Api/Users/Update';
 import AvatarImage from '../../AvatarImage';
 import packageV2 from '../paket-v2.svg';
 import { Speechbubble } from '../Speechbubble/index';
+import { campaignToAgs } from '../../utils';
 
 export default ({ userData, updateCustomUserData }) => {
   const [pledgePackageState, uploadPledgePackage] = useSaveInteraction();
   const [, setPledgePackage] = useState();
+  const [, updateUser] = useUpdateUser();
   const [campaignCode, setCampaignCode] = useState('bremen-1');
 
   useEffect(() => {
@@ -46,6 +49,16 @@ export default ({ userData, updateCustomUserData }) => {
   useEffect(() => {
     if (pledgePackageState === 'saved') {
       updateCustomUserData();
+
+      // Sign up user for municipality if they aren't already
+      if (
+        campaignToAgs[campaignCode] &&
+        !userData?.municipalities?.find(
+          ({ ags }) => ags === campaignToAgs[campaignCode]
+        )
+      ) {
+        updateUser({ ags: campaignToAgs[campaignCode] });
+      }
     }
   }, [pledgePackageState]);
 

--- a/src/components/PledgePackage/CreatePledgePackage/index.js
+++ b/src/components/PledgePackage/CreatePledgePackage/index.js
@@ -85,8 +85,6 @@ export default ({ userData, updateCustomUserData }) => {
         ];
       }
 
-      console.log('about to update user with data', data);
-
       if (shouldSubscribeToNewsletter || shouldSignUpForMunicipality) {
         updateUser(data);
       }

--- a/src/components/utils/index.js
+++ b/src/components/utils/index.js
@@ -250,6 +250,12 @@ export const stateToAgs = {
   hamburg: '02000000',
 };
 
+export const campaignToAgs = {
+  'berlin-1': '11000000',
+  'bremen-1': '04011000',
+  'hamburg-1': '02000000',
+};
+
 // Map campaign code to ags by extracting state out of campaign code
 // ad mapping that state to the ags
 export function mapCampaignCodeToAgs(campaignCode) {

--- a/src/components/utils/index.js
+++ b/src/components/utils/index.js
@@ -250,12 +250,6 @@ export const stateToAgs = {
   hamburg: '02000000',
 };
 
-export const campaignToAgs = {
-  'berlin-1': '11000000',
-  'bremen-1': '04011000',
-  'hamburg-1': '02000000',
-};
-
 // Map campaign code to ags by extracting state out of campaign code
 // ad mapping that state to the ags
 export function mapCampaignCodeToAgs(campaignCode) {


### PR DESCRIPTION
Resolves: https://expedition-grundeinkommen.monday.com/boards/853311751/pulses/1832417693

After package was created successfully the user is signed up for the municipality if not already the case. I did not introduce the state of the rest call, it's just being executed in the background. 

The user is not being signed up for the newsletter of the municipality though. I was unsure if it was the right place to do it. I can add that though. 

To test: go to mensch/{userId}/paket-nehmen?campaignCode={a campaign you are not signed up for, e.g. berlin-1) and create a package. You should be signed up for berlin then. If you replicate the steps, no new api call should be executed.