### PR TITLE
Package: isAuthenticated instead userId

### DIFF
--- a/src/components/PledgePackage/ListPledgePackages/PledgePackageSection.js
+++ b/src/components/PledgePackage/ListPledgePackages/PledgePackageSection.js
@@ -13,7 +13,11 @@ export const PledgePackagesSection = () => {
   const [state, pledgePackages, getInteractions] =
     useGetMostRecentInteractions();
   const [pledgePackagesDone, setPledgePackagesDone] = useState([]);
-  const { customUserData: userData, userId } = useContext(AuthContext);
+  const {
+    customUserData: userData,
+    isAuthenticated,
+    userId,
+  } = useContext(AuthContext);
   const [packagesOfUser, setPackagesOfUser] = useState([]);
   const { setShowModal } = useContext(OnboardingModalContext);
 
@@ -87,7 +91,7 @@ export const PledgePackagesSection = () => {
               </div>
             )}
             <div className={s.CTA}>
-              {userId ? (
+              {isAuthenticated ? (
                 <CTALink to={`/mensch/${userId}/paket-nehmen`}>
                   {userData && packagesOfUser.length === 0
                     ? 'Nimm dein Paket'


### PR DESCRIPTION
Es ist vielleicht sinnvoll, statt userId isAuthenticated abzufragen, sonst werden im identifizierten Zustand die eigenen Pakete nicht angezeigt. 

Goto: /playground/packages

Beispiel identified state, obwohl ich packages habe. 
![grafik](https://user-images.githubusercontent.com/19264520/147751092-14c686c9-bb1f-4dd7-bae1-43799d9b81a4.png)
