### PR TITLE
Fixed blog og image

### DIFF
--- a/src/components/BlogPost/index.js
+++ b/src/components/BlogPost/index.js
@@ -40,13 +40,19 @@ const BlogPost = ({
         {featuredImage && (
           <meta
             property="og:image"
-            content={featuredImage.node.localFile.childImageSharp.og.src}
+            content={
+              featuredImage.node.localFile.childImageSharp.og.images.fallback
+                .src
+            }
           />
         )}
         {featuredImage && (
           <meta
             name="twitter:image"
-            content={featuredImage.node.localFile.childImageSharp.og.src}
+            content={
+              featuredImage.node.localFile.childImageSharp.og.images.fallback
+                .src
+            }
           />
         )}
         {!featuredImage && <meta property="og:image" content={OGImage} />}


### PR DESCRIPTION
Resolves: https://expedition-grundeinkommen.monday.com/boards/853311751/pulses/1116342442

There should now be the correct og image for blog posts. The properties of the featuredImage were not used correctly (maybe something changed in the api?). 

You can test the og image with the facebook debug tool:
https://developers.facebook.com/tools/debug/?q=https%3A%2F%2Fdeploy-preview-377--expedition-grundeinkommen.netlify.app%2Fblog%2F2021%2F12%2F17%2F2022-wird-gross%2F