### PR TITLE
Navigate to municipality page after signup

### DIFF
--- a/src/components/Forms/SignUp/index.js
+++ b/src/components/Forms/SignUp/index.js
@@ -16,6 +16,7 @@ import { EnterLoginCode } from '../../Login/EnterLoginCode';
 import * as s from './style.module.less';
 import { MunicipalityContext } from '../../../context/Municipality';
 import { SearchPlaces } from '../SearchPlaces';
+import { navigate } from 'gatsby';
 
 // Not needed at the moment
 /* const AuthenticatedDialogDefault = () => {
@@ -49,7 +50,7 @@ export default ({
   } = useContext(AuthContext);
   const [formData, setFormData] = useState();
 
-  const { municipality, setMunicipality } = useContext(MunicipalityContext);
+  const { municipality } = useContext(MunicipalityContext);
   const [municipalityInForm, setMunicipalityInForm] = useState(municipality);
 
   let prefilledZip;
@@ -71,7 +72,8 @@ export default ({
 
       // Now set municipality in context
       if (municipalityInForm) {
-        setMunicipality(municipalityInForm);
+        console.log(municipalityInForm);
+        navigate(`/orte/${municipalityInForm.slug}`);
       }
 
       if (updateUserState === 'updated') {

--- a/src/components/Forms/SignUp/index.js
+++ b/src/components/Forms/SignUp/index.js
@@ -72,7 +72,6 @@ export default ({
 
       // Now set municipality in context
       if (municipalityInForm) {
-        console.log(municipalityInForm);
         navigate(`/orte/${municipalityInForm.slug}`);
       }
 


### PR DESCRIPTION
Resolves: https://expedition-grundeinkommen.monday.com/boards/853311751/pulses/2181938009

Auf deutsch, damit ich es nicht nochmal tippen muss: 
Wir (ich glaub vor allem ich :D) haben bei der Umstellung, dass wir die Startseite nicht mehr morphen, aus irgendeinem Grund vergessen, den Signup besser zu handlen. Es wird immer noch immer nach dem Signup die Municipality im Context gesetzt, was an sich unproblematisch ist, außer die Person schließt dann das Modal. 

Es wird nun einfach statt des Setzens im Kontext direkt nach dem Signup zur Gemeindeseite navigiert. 

Testen: Eingeloggt und ausgeloggt für eine Gemeinde anmelden, Schlauch durchlaufen etc. 