### PR TITLE
Fix EventsListed - loading state

### DIFF
--- a/src/components/Maps/EventsListed.js
+++ b/src/components/Maps/EventsListed.js
@@ -1,27 +1,43 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import * as s from './style.module.less';
 import * as dsm from './utils/dateStringManipulation';
 import { LoadingAnimation } from '../LoadingAnimation';
 
+/* The "EventsListed" Component should only display data,
+when there were events in the next days.
+
+Otherwise it renders nothing. */
+
 export const EventsListed = ({ locationsFiltered }) => {
-  let groupedEvents = {};
-  let locationsSorted = [];
+  const [loading, setLoading] = useState(false);
+  const [groupedEvents, setGroupedEvents] = useState({});
+
+  useEffect(() => {
+    if (locationsFiltered) {
+      setLoading(true);
+      const locationsSorted = locationsFiltered
+        ?.filter(location => location.startTime && location.endTime)
+        .sort(function (a, b) {
+          return new Date(a.startTime) - new Date(b.startTime);
+        });
+      const grouped = groupByDate(locationsSorted);
+      setGroupedEvents(grouped);
+      setLoading(false);
+    }
+  }, [locationsFiltered]);
 
   const groupByDate = locations => {
+    const grEvents = {};
     locations.forEach(location => {
       const eventDate = dsm.getGermanDateFormat(location.startTime);
-      if (!(eventDate in groupedEvents)) groupedEvents[eventDate] = [];
-      groupedEvents[eventDate].push(location);
+      if (!(eventDate in grEvents)) grEvents[eventDate] = [];
+      grEvents[eventDate].push(location);
     });
+    return grEvents;
   };
 
-  if (locationsFiltered) {
-    locationsSorted = locationsFiltered
-      ?.filter(location => location.startTime && location.endTime)
-      .sort(function (a, b) {
-        return new Date(a.startTime) - new Date(b.startTime);
-      });
-    groupByDate(locationsSorted);
+  if (loading) {
+    return <LoadingAnimation />;
   }
 
   return (
@@ -54,9 +70,7 @@ export const EventsListed = ({ locationsFiltered }) => {
             })}
           </div>
         </>
-      ) : (
-        <LoadingAnimation />
-      )}
+      ) : null}
     </>
   );
 };


### PR DESCRIPTION
This PR fixes the EventsListed component. The problem was, that if no events are in the near future, that have a start and endtime, the loading animation was displayed indefinitely.

Now the component should just not render, when there is nothing to show.