### PR TITLE
Black heading on image

### DIFF
--- a/src/components/Layout/Sections/style.module.less
+++ b/src/components/Layout/Sections/style.module.less
@@ -392,6 +392,10 @@
   min-height: 30vw;
   display: flex;
   align-items: flex-end;
+
+  .headerTitle {
+    --heading-color: @black;
+  }
 }
 
 .spaceBetweenBlogAndCTA {


### PR DESCRIPTION
Resolves: https://expedition-grundeinkommen.monday.com/boards/853311751/pulses/2211578795

Pretty self-explanatory:
Headings on sections with image should be black, not violet. E.g. on the blog