### PR TITLE
Prevent morphing the home page, when municipality is selected

### DIFF
--- a/src/components/IntroText/index.js
+++ b/src/components/IntroText/index.js
@@ -8,7 +8,7 @@ import { StaticImage } from 'gatsby-plugin-image';
 
 import { SignupButtonAndTile } from '../TickerToSignup/SignupButtonAndTile';
 import { useUserMunicipalityState } from '../../hooks/Municipality/UserMunicipalityState';
-import { currentURL } from '../utils/currentURL';
+import { isMunicipalityPage } from '../utils/currentURL';
 
 export const IntroText = ({
   highlightText: { highlightText },
@@ -19,7 +19,7 @@ export const IntroText = ({
   // Don't render this component if user has signed up for this municipality
   if (
     userMunicipalityState === 'loggedInThisMunicipalitySignup' &&
-    currentURL.includes('orte')
+    isMunicipalityPage
   ) {
     return null;
   }

--- a/src/components/IntroText/index.js
+++ b/src/components/IntroText/index.js
@@ -8,6 +8,7 @@ import { StaticImage } from 'gatsby-plugin-image';
 
 import { SignupButtonAndTile } from '../TickerToSignup/SignupButtonAndTile';
 import { useUserMunicipalityState } from '../../hooks/Municipality/UserMunicipalityState';
+import { currentURL } from '../utils/currentURL';
 
 export const IntroText = ({
   highlightText: { highlightText },
@@ -16,7 +17,10 @@ export const IntroText = ({
   const userMunicipalityState = useUserMunicipalityState();
 
   // Don't render this component if user has signed up for this municipality
-  if (userMunicipalityState === 'loggedInThisMunicipalitySignup') {
+  if (
+    userMunicipalityState === 'loggedInThisMunicipalitySignup' &&
+    currentURL.includes('orte')
+  ) {
     return null;
   }
 

--- a/src/components/Layout/Sections/RenderPage.js
+++ b/src/components/Layout/Sections/RenderPage.js
@@ -18,9 +18,7 @@ export const RenderPage = ({ sections, pageContext }) => {
     sections,
     pageContext,
     userMunicipalityState,
-  })?.map((section, index) => (
-    <React.Fragment key={index}>{section}</React.Fragment>
-  ));
+  })?.map((section, index) => <div key={index}>{section}</div>);
 
   if (municipality) {
     // Add news component as second component

--- a/src/components/Layout/Sections/index.js
+++ b/src/components/Layout/Sections/index.js
@@ -29,7 +29,7 @@ import AuthContext from '../../../context/Authentication';
 import { LinkButton } from '../../Forms/Button';
 import loadable from '@loadable/component';
 import Maps from '../../Maps';
-import { currentURL } from '../../utils/currentURL';
+import { isMunicipalityPage } from '../../utils/currentURL';
 
 const SignUp = loadable(() => import('../../Forms/SignUp'));
 const Pledge = loadable(() => import('../../Forms/Pledge'));
@@ -195,7 +195,7 @@ export function ContentfulSection({ section, pageContext }) {
                 <div className={s.keyClaim}>
                   <h1>
                     Hol das Grundeinkommen jetzt{' '}
-                    {municipality && currentURL.includes('orte')
+                    {municipality && isMunicipalityPage
                       ? `nach ${municipality.name}`
                       : 'in deinen Wohnort'}
                     .

--- a/src/components/Layout/Sections/index.js
+++ b/src/components/Layout/Sections/index.js
@@ -29,6 +29,7 @@ import AuthContext from '../../../context/Authentication';
 import { LinkButton } from '../../Forms/Button';
 import loadable from '@loadable/component';
 import Maps from '../../Maps';
+import { currentURL } from '../../utils/currentURL';
 
 const SignUp = loadable(() => import('../../Forms/SignUp'));
 const Pledge = loadable(() => import('../../Forms/Pledge'));
@@ -194,7 +195,7 @@ export function ContentfulSection({ section, pageContext }) {
                 <div className={s.keyClaim}>
                   <h1>
                     Hol das Grundeinkommen jetzt{' '}
-                    {municipality
+                    {municipality && currentURL.includes('orte')
                       ? `nach ${municipality.name}`
                       : 'in deinen Wohnort'}
                     .

--- a/src/components/Layout/index.js
+++ b/src/components/Layout/index.js
@@ -11,6 +11,7 @@ import { Overlay } from '../Overlay';
 import { StickyBannerContext } from '../../context/StickyBanner';
 import AuthContext from '../../context/Authentication';
 import { buildVisualisationsWithCrowdfunding } from '../../hooks/Api/Crowdfunding';
+import { currentURL } from '../utils/currentURL';
 
 const DEFAULT_SITE_TITLE = 'Expedition Grundeinkommen';
 const BERLIN_SITE_TITLE = 'Expedition Grundeinkommen Berlin';
@@ -178,9 +179,7 @@ function Template({ children, sections, pageContext, title, description }) {
   // update current URL in banner context, to check for pages where banner shoud not appear
   // context itself does not reload on route change, so we set it from layout component
   useEffect(() => {
-    setCurrentURL(
-      typeof window !== 'undefined' ? window.location.pathname : ''
-    );
+    setCurrentURL(currentURL);
   });
 
   // NOTE: not needed until banner is activated again

--- a/src/components/Municipality/MapAndSearch/MunicipalityMoreDetails.jsx
+++ b/src/components/Municipality/MapAndSearch/MunicipalityMoreDetails.jsx
@@ -1,15 +1,12 @@
 import { navigate } from 'gatsby';
-import React, { useContext } from 'react';
+import React from 'react';
 import { CampainVisualisation } from '../../CampaignVisualisations/index';
 import { Button } from '../../Forms/Button/index';
 import * as s from './style.module.less';
-import { MunicipalityContext } from '../../../context/Municipality/index';
 
 export const MunicipalityMoreDetails = ({
   municipality: municipalityToDisplay,
 }) => {
-  const { municipality } = useContext(MunicipalityContext);
-
   return (
     <section className={s.expandedRow}>
       {municipalityToDisplay?.goal && (
@@ -34,16 +31,14 @@ export const MunicipalityMoreDetails = ({
           currency="Anmeldungen"
         />
       )}
-      {municipality?.ags !== municipalityToDisplay?.ags && (
-        <div className={s.buttonContainer}>
-          <Button
-            className={s.municipalityButton}
-            onClick={() => navigate(`/orte/${municipalityToDisplay.slug}`)}
-          >
-            Zur Ortsseite
-          </Button>
-        </div>
-      )}
+      <div className={s.buttonContainer}>
+        <Button
+          className={s.municipalityButton}
+          onClick={() => navigate(`/orte/${municipalityToDisplay.slug}`)}
+        >
+          Zur Ortsseite
+        </Button>
+      </div>
     </section>
   );
 };

--- a/src/components/Municipality/MapAndSearch/index.js
+++ b/src/components/Municipality/MapAndSearch/index.js
@@ -7,7 +7,6 @@ import { Leaderboard } from '../Leaderboard';
 import { QualifiedBoard } from '../Leaderboard/QualifiedBoard';
 import { ExpandableRow } from './ExpandableRow';
 import { MunicipalityContext } from '../../../context/Municipality';
-import { isMunicipalityPage } from '../../utils/currentURL';
 
 const MunicipalityMap = loadable(() => import('../MunicipalityMap'));
 
@@ -24,7 +23,7 @@ export const MapAndSearch = () => {
   }, [leaderboardSegments]);
 
   useEffect(() => {
-    if (municipality && isMunicipalityPage) {
+    if (municipality) {
       setHighlightedMunicipality(municipality);
     }
   }, [municipality]);

--- a/src/components/Municipality/MapAndSearch/index.js
+++ b/src/components/Municipality/MapAndSearch/index.js
@@ -7,6 +7,7 @@ import { Leaderboard } from '../Leaderboard';
 import { QualifiedBoard } from '../Leaderboard/QualifiedBoard';
 import { ExpandableRow } from './ExpandableRow';
 import { MunicipalityContext } from '../../../context/Municipality';
+import { currentURL } from '../../utils/currentURL';
 
 const MunicipalityMap = loadable(() => import('../MunicipalityMap'));
 
@@ -23,7 +24,7 @@ export const MapAndSearch = () => {
   }, [leaderboardSegments]);
 
   useEffect(() => {
-    if (municipality) {
+    if (municipality && currentURL.includes('orte')) {
       setHighlightedMunicipality(municipality);
     }
   }, [municipality]);

--- a/src/components/Municipality/MapAndSearch/index.js
+++ b/src/components/Municipality/MapAndSearch/index.js
@@ -7,7 +7,7 @@ import { Leaderboard } from '../Leaderboard';
 import { QualifiedBoard } from '../Leaderboard/QualifiedBoard';
 import { ExpandableRow } from './ExpandableRow';
 import { MunicipalityContext } from '../../../context/Municipality';
-import { currentURL } from '../../utils/currentURL';
+import { isMunicipalityPage } from '../../utils/currentURL';
 
 const MunicipalityMap = loadable(() => import('../MunicipalityMap'));
 
@@ -24,7 +24,7 @@ export const MapAndSearch = () => {
   }, [leaderboardSegments]);
 
   useEffect(() => {
-    if (municipality && currentURL.includes('orte')) {
+    if (municipality && isMunicipalityPage) {
       setHighlightedMunicipality(municipality);
     }
   }, [municipality]);

--- a/src/components/Municipality/MunicipalityGroups/index.js
+++ b/src/components/Municipality/MunicipalityGroups/index.js
@@ -5,6 +5,7 @@ import { contentfulJsonToHtml } from '../../utils/contentfulJsonToHtml';
 import { InlineLinkButton } from '../../Forms/Button';
 import { SignUpButton } from '../../TickerToSignup/SignupButton';
 import * as s from './style.module.less';
+import { isMunicipalityPage } from '../../utils/currentURL';
 
 export const MunicipalityGroups = ({ body }) => {
   const { isAuthenticated, customUserData: userData } = useContext(AuthContext);
@@ -14,7 +15,7 @@ export const MunicipalityGroups = ({ body }) => {
 
   // If municipality is set (meaning user is on municipality page) we want to show groups
   // for this municipality
-  if (municipality) {
+  if (municipality && isMunicipalityPage) {
     return (
       <>
         {introText}

--- a/src/components/Municipality/MunicipalityInfoText/index.js
+++ b/src/components/Municipality/MunicipalityInfoText/index.js
@@ -3,6 +3,7 @@ import * as s from './style.module.less';
 import { MunicipalityProgress } from '../MunicipalityProgress';
 import { MunicipalityContext } from '../../../context/Municipality';
 import { useUserMunicipalityState } from '../../../hooks/Municipality/UserMunicipalityState';
+import { currentURL } from '../../utils/currentURL';
 
 export const MunicipalityInfoText = () => {
   const { municipality } = useContext(MunicipalityContext);
@@ -16,7 +17,7 @@ export const MunicipalityInfoText = () => {
     return null;
   }
 
-  if (municipality) {
+  if (municipality && currentURL.includes('orte')) {
     return (
       <div className={s.municipalityText}>
         <p className={s.municipalityTextIntro}>

--- a/src/components/Municipality/MunicipalityInfoText/index.js
+++ b/src/components/Municipality/MunicipalityInfoText/index.js
@@ -3,7 +3,7 @@ import * as s from './style.module.less';
 import { MunicipalityProgress } from '../MunicipalityProgress';
 import { MunicipalityContext } from '../../../context/Municipality';
 import { useUserMunicipalityState } from '../../../hooks/Municipality/UserMunicipalityState';
-import { currentURL } from '../../utils/currentURL';
+import { isMunicipalityPage } from '../../utils/currentURL';
 
 export const MunicipalityInfoText = () => {
   const { municipality } = useContext(MunicipalityContext);
@@ -17,7 +17,7 @@ export const MunicipalityInfoText = () => {
     return null;
   }
 
-  if (municipality && currentURL.includes('orte')) {
+  if (municipality && isMunicipalityPage) {
     return (
       <div className={s.municipalityText}>
         <p className={s.municipalityTextIntro}>

--- a/src/components/Municipality/MunicipalityProgress/index.js
+++ b/src/components/Municipality/MunicipalityProgress/index.js
@@ -4,6 +4,7 @@ import { MunicipalityContext } from '../../../context/Municipality';
 
 import * as s from './style.module.less';
 import { useUserMunicipalityState } from '../../../hooks/Municipality/UserMunicipalityState';
+import { currentURL } from '../../utils/currentURL';
 
 export const MunicipalityProgress = ({
   showHeadline = true,
@@ -14,9 +15,11 @@ export const MunicipalityProgress = ({
   const userMunicipalityState = useUserMunicipalityState();
 
   // Don't render this component if user has not signed up for this municipality
+  // Or if user is not on municipality page
   if (
-    !isPartOfInfoText &&
-    userMunicipalityState !== 'loggedInThisMunicipalitySignup'
+    (!isPartOfInfoText &&
+      userMunicipalityState !== 'loggedInThisMunicipalitySignup') ||
+    !currentURL.includes('orte')
   ) {
     return null;
   }

--- a/src/components/Municipality/MunicipalityProgress/index.js
+++ b/src/components/Municipality/MunicipalityProgress/index.js
@@ -4,7 +4,7 @@ import { MunicipalityContext } from '../../../context/Municipality';
 
 import * as s from './style.module.less';
 import { useUserMunicipalityState } from '../../../hooks/Municipality/UserMunicipalityState';
-import { currentURL } from '../../utils/currentURL';
+import { isMunicipalityPage } from '../../utils/currentURL';
 
 export const MunicipalityProgress = ({
   showHeadline = true,
@@ -19,7 +19,7 @@ export const MunicipalityProgress = ({
   if (
     (!isPartOfInfoText &&
       userMunicipalityState !== 'loggedInThisMunicipalitySignup') ||
-    !currentURL.includes('orte')
+    !isMunicipalityPage
   ) {
     return null;
   }

--- a/src/components/Profile/ProfileTile/index.js
+++ b/src/components/Profile/ProfileTile/index.js
@@ -10,7 +10,7 @@ import * as s from './style.module.less';
 import * as cS from '../../style/colorSchemes.module.less';
 import cN from 'classnames';
 import { getReferredUserMessage } from '../utils/referredUserMessage';
-import { currentURL } from '../../utils/currentURL';
+import { isMunicipalityPage } from '../../utils/currentURL';
 
 export const ProfileTile = ({ children }) => {
   const { userId, customUserData: userData } = useContext(AuthContext);
@@ -58,7 +58,7 @@ const TileLoggedInThisMunicipality = ({ userId, userData, municipality }) => {
 
   return (
     <>
-      {userData && currentURL.includes('orte') && (
+      {userData && isMunicipalityPage && (
         <section>
           <div className={cN(s.tileFlexContainer, cS.colorSchemeViolet)}>
             <div className={s.centeredAvatar}>

--- a/src/components/Profile/ProfileTile/index.js
+++ b/src/components/Profile/ProfileTile/index.js
@@ -10,6 +10,7 @@ import * as s from './style.module.less';
 import * as cS from '../../style/colorSchemes.module.less';
 import cN from 'classnames';
 import { getReferredUserMessage } from '../utils/referredUserMessage';
+import { currentURL } from '../../utils/currentURL';
 
 export const ProfileTile = ({ children }) => {
   const { userId, customUserData: userData } = useContext(AuthContext);
@@ -57,7 +58,7 @@ const TileLoggedInThisMunicipality = ({ userId, userData, municipality }) => {
 
   return (
     <>
-      {userData && (
+      {userData && currentURL.includes('orte') && (
         <section>
           <div className={cN(s.tileFlexContainer, cS.colorSchemeViolet)}>
             <div className={s.centeredAvatar}>

--- a/src/components/Profile/ProfileTile/index.js
+++ b/src/components/Profile/ProfileTile/index.js
@@ -113,11 +113,7 @@ const TileLoggedInThisMunicipality = ({ userId, userData, municipality }) => {
   );
 };
 
-const TileNoMunicipalityLoggedInOtherMunicipality = ({
-  userId,
-  userData,
-  setMunicipality,
-}) => {
+const TileNoMunicipalityLoggedInOtherMunicipality = ({ userId, userData }) => {
   return (
     <>
       {userData && (

--- a/src/components/TickerToSignup/SignupButtonAndTile/index.js
+++ b/src/components/TickerToSignup/SignupButtonAndTile/index.js
@@ -7,6 +7,7 @@ import * as s from './style.module.less';
 import cN from 'classnames';
 
 import { SignUpButton } from '../SignupButton';
+import { currentURL } from '../../utils/currentURL';
 
 export const SignupButtonAndTile = ({ className }) => {
   // const { userId, customUserData: userData } = useContext(AuthContext);
@@ -50,7 +51,7 @@ export const SignupButtonAndTile = ({ className }) => {
 };
 
 export const getButtonText = (municipality, userMunicipalityState) => {
-  if (!municipality) {
+  if (!municipality || !currentURL.includes('orte')) {
     return 'Ich will dabei sein';
   }
 
@@ -75,7 +76,7 @@ export const getButtonText = (municipality, userMunicipalityState) => {
 };
 
 const getWelcomeExistingMessage = municipality => {
-  if (!municipality) {
+  if (!municipality || !currentURL.includes('orte')) {
     return '';
   }
   // Berlin

--- a/src/components/TickerToSignup/SignupButtonAndTile/index.js
+++ b/src/components/TickerToSignup/SignupButtonAndTile/index.js
@@ -7,7 +7,7 @@ import * as s from './style.module.less';
 import cN from 'classnames';
 
 import { SignUpButton } from '../SignupButton';
-import { currentURL } from '../../utils/currentURL';
+import { isMunicipalityPage } from '../../utils/currentURL';
 
 export const SignupButtonAndTile = ({ className }) => {
   // const { userId, customUserData: userData } = useContext(AuthContext);
@@ -51,7 +51,7 @@ export const SignupButtonAndTile = ({ className }) => {
 };
 
 export const getButtonText = (municipality, userMunicipalityState) => {
-  if (!municipality || !currentURL.includes('orte')) {
+  if (!municipality || !isMunicipalityPage) {
     return 'Ich will dabei sein';
   }
 
@@ -76,7 +76,7 @@ export const getButtonText = (municipality, userMunicipalityState) => {
 };
 
 const getWelcomeExistingMessage = municipality => {
-  if (!municipality || !currentURL.includes('orte')) {
+  if (!municipality || !isMunicipalityPage) {
     return '';
   }
   // Berlin

--- a/src/components/TickerToSignup/index.js
+++ b/src/components/TickerToSignup/index.js
@@ -8,7 +8,7 @@ import * as s from './style.module.less';
 import loadable from '@loadable/component';
 import { List as Loader } from 'react-content-loader';
 import { useUserMunicipalityState } from '../../hooks/Municipality/UserMunicipalityState';
-import { currentURL } from '../utils/currentURL';
+import { isMunicipalityPage } from '../utils/currentURL';
 
 const Ticker = loadable(() => import('./Ticker'));
 const TickerMunicipality = loadable(() =>
@@ -24,7 +24,7 @@ export const TickerToSignup = ({
   // Don't render this component if user has signed up for this municipality
   if (
     userMunicipalityState === 'loggedInThisMunicipalitySignup' &&
-    currentURL.includes('orte')
+    isMunicipalityPage
   ) {
     return null;
   }
@@ -35,7 +35,7 @@ export const TickerToSignup = ({
     <>
       {/* A hidden Heading to improve accessibility */}
       <h2 className={s.hiddenHeading}>Anmelden</h2>
-      {municipality?.ags && currentURL.includes('orte') ? (
+      {municipality?.ags && isMunicipalityPage ? (
         <TickerMunicipality
           tickerDescription={tickerDescription}
           fallback={<Loader />}

--- a/src/components/TickerToSignup/index.js
+++ b/src/components/TickerToSignup/index.js
@@ -8,6 +8,7 @@ import * as s from './style.module.less';
 import loadable from '@loadable/component';
 import { List as Loader } from 'react-content-loader';
 import { useUserMunicipalityState } from '../../hooks/Municipality/UserMunicipalityState';
+import { currentURL } from '../utils/currentURL';
 
 const Ticker = loadable(() => import('./Ticker'));
 const TickerMunicipality = loadable(() =>
@@ -31,7 +32,7 @@ export const TickerToSignup = ({
     <>
       {/* A hidden Heading to improve accessibility */}
       <h2 className={s.hiddenHeading}>Anmelden</h2>
-      {municipality?.ags ? (
+      {municipality?.ags && currentURL.includes('orte') ? (
         <TickerMunicipality
           tickerDescription={tickerDescription}
           fallback={<Loader />}

--- a/src/components/TickerToSignup/index.js
+++ b/src/components/TickerToSignup/index.js
@@ -22,7 +22,10 @@ export const TickerToSignup = ({
   const userMunicipalityState = useUserMunicipalityState();
 
   // Don't render this component if user has signed up for this municipality
-  if (userMunicipalityState === 'loggedInThisMunicipalitySignup') {
+  if (
+    userMunicipalityState === 'loggedInThisMunicipalitySignup' &&
+    currentURL.includes('orte')
+  ) {
     return null;
   }
 

--- a/src/components/utils/currentURL.js
+++ b/src/components/utils/currentURL.js
@@ -1,2 +1,4 @@
 export const currentURL =
   typeof window !== 'undefined' ? window.location.href : '';
+
+export const isMunicipalityPage = currentURL.includes('orte');

--- a/src/components/utils/currentURL.js
+++ b/src/components/utils/currentURL.js
@@ -1,0 +1,2 @@
+export const currentURL =
+  typeof window !== 'undefined' ? window.location.href : '';

--- a/src/components/utils/index.js
+++ b/src/components/utils/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { List as Loader } from 'react-content-loader';
+import { isMunicipalityPage } from './currentURL';
 // create a valid ID for usage in the DOM
 export function stringToId(string) {
   return string && string.toString().replace(/^[^a-z]+|[^\w:.-]+/gi, '');
@@ -305,6 +306,11 @@ export const getFilteredElementsByContentfulState = ({
       userMunicipalityState === 'loggedInThisMunicipalitySignup'
     ) {
       showState = false;
+    }
+
+    // Check if we are on a municipality page and render section if not
+    if (!isMunicipalityPage) {
+      showState = true;
     }
 
     return showState;


### PR DESCRIPTION
This pr add checks, if we are on a municipality page, when content of the main page / municipality page should change due to the selected municipality in the context.

It is more of a temporary fix, but a more elaborate solution would require more work.