### PR TITLE
Hide listed events in map iframe

### DIFF
--- a/src/components/Maps/ShowMeetups.js
+++ b/src/components/Maps/ShowMeetups.js
@@ -312,7 +312,7 @@ export const ShowMeetups = ({ mapConfig, className, isIframe = false }) => {
               </SectionComponentContainer>
             </>
           )}
-          <EventsListed locationsFiltered={locationsFiltered} />
+          {!isIframe && <EventsListed locationsFiltered={locationsFiltered} />}
         </div>
       )}
     </>


### PR DESCRIPTION
This PR hides the listed events from the iframe map. It should be extracted to an additional iframe component.