### PR TITLE
Add colorscheme to meetup form to fix focus state

### DIFF
--- a/src/components/Forms/Meetup/style.module.less
+++ b/src/components/Forms/Meetup/style.module.less
@@ -1,6 +1,9 @@
 @import '../../style/vars.less';
+@import '../../style/colorSchemes.module.less';
 
 .section {
+  .colorSchemeWhite;
+
   width: 100%;
   padding: 1rem 2rem;
   height: 90%;


### PR DESCRIPTION
Resolves: https://expedition-grundeinkommen.monday.com/boards/853311751/pulses/2383884244

The issue was actually only in the meetup form, because it seemed in the refactoring we forgot to add the color scheme to the component. 

Test: goto /demokratie-fuer-alle, open meetup form and check if the focus state of the input fields is correct. 