### PR TITLE
Three column layout for components

### DIFF
--- a/src/components/Layout/Sections/index.js
+++ b/src/components/Layout/Sections/index.js
@@ -625,6 +625,9 @@ export function SectionComponent({ children, column, className }) {
         {
           [s.componentLeft]: column === 'left',
           [s.componentRight]: column === 'right',
+          [s.componentLeftThird]: column === 'leftThird',
+          [s.componentCenterThird]: column === 'centerThird',
+          [s.componentRightThird]: column === 'rightThird',
           [s.componentCenterWide]: column === 'centerWide',
           [s.componentCenterNarrow]: column === 'centerNarrow',
         },

--- a/src/components/Layout/Sections/style.module.less
+++ b/src/components/Layout/Sections/style.module.less
@@ -600,7 +600,7 @@
   margin: auto;
   margin-top: 2rem;
   display: grid;
-  grid-template-columns: 25% 25% 25% 25%;
+  grid-template-columns: repeat(6, 1fr);
   grid-template-rows: auto;
 
   @media (max-width: @breakPointL) {
@@ -619,7 +619,7 @@
   @media (min-width: @breakPointL) {
     padding-right: 2.5rem;
     grid-column-start: 1;
-    grid-column-end: 3;
+    grid-column-end: 4;
     margin-bottom: 0;
   }
 }
@@ -629,8 +629,41 @@
   grid-column-end: last-line;
   @media (min-width: @breakPointL) {
     padding-left: 2.5rem;
-    grid-column-start: 3;
+    grid-column-start: 4;
     grid-column-end: last-line;
+  }
+}
+
+.componentLeftThird {
+  grid-column-start: 1;
+  grid-column-end: last-line;
+
+  @media (min-width: @breakPointL) {
+    padding-right: 2.5rem;
+    grid-column-start: 1;
+    grid-column-end: 3;
+    margin-bottom: 0;
+  }
+}
+
+.componentRightThird {
+  grid-column-start: 1;
+  grid-column-end: last-line;
+  @media (min-width: @breakPointL) {
+    padding-left: 2.5rem;
+    grid-column-start: 5;
+    grid-column-end: last-line;
+  }
+}
+
+.componentCenterThird {
+  grid-column-start: 1;
+  grid-column-end: last-line;
+  @media (min-width: @breakPointL) {
+    padding-left: 2.5rem;
+    padding-right: 2.5rem;
+    grid-column-start: 3;
+    grid-column-end: 5;
   }
 }
 


### PR DESCRIPTION
Resolves: https://expedition-grundeinkommen.monday.com/boards/853311751/pulses/2488847138

You can now place section components within a three column layout by assigning column "leftThird", "centerThird" or "rightThird".

I created a static page under /test-dreier-layout for you to check out the layout or play around with: https://app.contentful.com/spaces/af08tobnb0cl/entries/2uvKbVsx2FJbi0OiVwuLHQ 

Also maybe check out, if the half half layout is not broken by the changes. Because I had to redefine the layout into six parts instead of four to accomodate for both layout possibilities. 