### PR TITLE
Use two different endpoints for events and list locations

### DIFF
--- a/src/components/Forms/Meetup/index.js
+++ b/src/components/Forms/Meetup/index.js
@@ -138,6 +138,22 @@ export const CreateMeetup = ({
 
             <Form
               onSubmit={e => {
+                // Depemding on the type of the location a location has its street in the text property
+                // or not (if not, we have to extract it from place name)
+                let street;
+                let number;
+                if (location.place_type?.[0] === 'address') {
+                  street = location.text;
+                  number = location.address;
+                } else {
+                  // split by "," to get address and then split " " to remove number
+                  const addressArray = location.place_name
+                    .split(',')[1]
+                    .split(' ');
+                  number = addressArray.pop();
+                  street = addressArray.join(' ');
+                }
+
                 const data = {
                   locationName: e.name,
                   description: e.description,
@@ -146,6 +162,8 @@ export const CreateMeetup = ({
                   address: location.address
                     ? `${location.text} ${location.address}`
                     : location.text,
+                  street,
+                  number,
                   city: location.context.find(({ id }) =>
                     id.startsWith('place')
                   )?.text,
@@ -225,35 +243,37 @@ export const CreateMeetup = ({
                     )}
                     <div ref={scrollToRef}></div>
 
-                    <FormSection>
-                      <p>
-                        Bitte gib ein paar zusätzliche Infos an. Wo willst du
-                        sammeln? Sollen die anderen Sammler*innen etwas
-                        mitbringen? Wie findet ihr zueinander?
-                      </p>
-                      <Field
-                        name="description"
-                        label="Beschreibung"
-                        placeholder="Sag ein paar Sätze zum geplanten Event..."
-                        type="textarea"
-                        inputClassName={s.textarea}
-                        component={TextInputWrapped}
-                      ></Field>
-                      <p>
-                        Gib ein paar Infos über dich an: Woran erkennt man dich
-                        vor Ort und wie kann man dich kontaktieren? Bitte
-                        beachte, dass diese Angaben öffentlich auf der Karte zu
-                        sehen sein werden.
-                      </p>
-                      <Field
-                        name="contact"
-                        label="Informationen über dich"
-                        placeholder="Beschreibung"
-                        type="textarea"
-                        inputClassName={cN(s.textarea, s.shortTextarea)}
-                        component={TextInputWrapped}
-                      ></Field>
-                    </FormSection>
+                    {type === 'collect' && (
+                      <FormSection>
+                        <p>
+                          Bitte gib ein paar zusätzliche Infos an. Wo willst du
+                          sammeln? Sollen die anderen Sammler*innen etwas
+                          mitbringen? Wie findet ihr zueinander?
+                        </p>
+                        <Field
+                          name="description"
+                          label="Beschreibung"
+                          placeholder="Sag ein paar Sätze zum geplanten Event..."
+                          type="textarea"
+                          inputClassName={s.textarea}
+                          component={TextInputWrapped}
+                        ></Field>
+                        <p>
+                          Gib ein paar Infos über dich an: Woran erkennt man
+                          dich vor Ort und wie kann man dich kontaktieren? Bitte
+                          beachte, dass diese Angaben öffentlich auf der Karte
+                          zu sehen sein werden.
+                        </p>
+                        <Field
+                          name="contact"
+                          label="Informationen über dich"
+                          placeholder="Beschreibung"
+                          type="textarea"
+                          inputClassName={cN(s.textarea, s.shortTextarea)}
+                          component={TextInputWrapped}
+                        ></Field>
+                      </FormSection>
+                    )}
 
                     <CTAButtonContainer className={s.buttonContainer}>
                       <CTAButton type="submit" size="MEDIUM">
@@ -274,10 +294,6 @@ export const CreateMeetup = ({
 const validate = (values, type) => {
   const errors = {};
 
-  if (!values.description) {
-    errors.description = 'Bitte gib eine kurze Beschreibung an';
-  }
-
   if (type === 'lists' && !values.name) {
     errors.name = 'Bitte gib einen Namen des Sammelortes an';
   }
@@ -293,6 +309,10 @@ const validate = (values, type) => {
 
     if (!values.end) {
       errors.end = 'Bitte gib ein Ende an';
+    }
+
+    if (!values.description) {
+      errors.description = 'Bitte gib eine kurze Beschreibung an';
     }
   }
 

--- a/src/components/Maps/EventsListed.js
+++ b/src/components/Maps/EventsListed.js
@@ -60,7 +60,7 @@ export const EventsListed = ({ locationsFiltered }) => {
                           {dsm.localeTime(event.startTime)}-
                           {dsm.localeTime(event.endTime)}
                           {' Uhr, '}
-                          {event.address}
+                          {event.address || event.locationName}
                         </b>
                       </div>
                     );

--- a/src/components/Maps/LazyMap.js
+++ b/src/components/Maps/LazyMap.js
@@ -267,7 +267,16 @@ const PopupContent = ({
             />
             <div className={s.tooltipLocation}>
               <span className={s.tooltipAddress}>
-                {address || locationName}
+                {/* If address and location name both exist, show both, otherwise only one */}
+                {address && locationName ? (
+                  <>
+                    {address}
+                    <br />
+                    {locationName}
+                  </>
+                ) : (
+                  address || locationName
+                )}
               </span>
               <br />
               {zipCode && city && (

--- a/src/components/Maps/ShowMeetups.js
+++ b/src/components/Maps/ShowMeetups.js
@@ -76,6 +76,11 @@ export const ShowMeetups = ({ mapConfig, className, isIframe = false }) => {
     // We only need to fetch meetups from secondary API if it's the berlin or hamburg map
     if (isBerlin || isHamburg || isDemocracy) {
       // We pass state to differentiate between APIs
+
+      // The whole naming of meetups does not really make that much sense anymore, since
+      // we are using the new api backend structure, where list locations and events are two
+      // entirely different api and schemas.
+      // I am leaving it like this anyway, just beware that meetups are events OR list locations
       getMeetups(mapConfig.state);
     }
   }, [mapConfig]);
@@ -138,7 +143,6 @@ export const ShowMeetups = ({ mapConfig, className, isIframe = false }) => {
             );
           }
         );
-
         setLocationsFiltered(newLocationsFiltered);
       }
     }

--- a/src/hooks/Api/Meetups/Get/index.js
+++ b/src/hooks/Api/Meetups/Get/index.js
@@ -1,9 +1,14 @@
 /**
- * These hooks make use of the app backend (of the DWE enteignen app) to fetch collection meetups
+ * These hooks make use of the app backend (of the DWE enteignen app) or our own backend to fetch collection meetups
  */
 
 import { useState } from 'react';
 import CONFIG from '../../../../../backend-config';
+
+// The whole naming of meetups does not really make that much sense anymore, since
+// we are using the new api backend structure, where list locations and events are two
+// entirely different api and schemas.
+// I am leaving it like this anyway, just beware that meetups are events OR list locations
 
 export const useGetMeetups = () => {
   const [meetups, setMeetups] = useState();
@@ -17,36 +22,57 @@ const getMeetups = async (state, setMeetups) => {
   try {
     const isBerlin = state === 'berlin';
 
-    let response;
     if (isBerlin) {
-      response = await getMeetupsFromAppApi();
+      // In comparison to the way we handle events and list locations in our backend
+      // those two types are two different api endpoints in the app backend
+      const [eventsResponse, listLocationsResponse] = await Promise.all([
+        getEventsFromAppApi(),
+        getListLocationsFromAppApi(),
+      ]);
+
+      if (
+        eventsResponse.status === 200 &&
+        listLocationsResponse.status === 200
+      ) {
+        // We don't need to thoroughly format list locations, only event meetups
+        const events = formatMeetups(true, false, await eventsResponse.json());
+        const listLocations = formatMeetups(
+          true,
+          true,
+          await listLocationsResponse.json()
+        );
+
+        setMeetups([...events, ...listLocations]);
+      } else {
+        console.log(
+          'Response is not 200',
+          eventsResponse.status,
+          listLocationsResponse.status
+        );
+      }
     } else {
-      response = await getMeetupsFromWebsiteApi();
-    }
+      const response = await getMeetupsFromWebsiteApi();
 
-    if (response.status === 200) {
-      const json = await response.json();
+      if (response.status === 200) {
+        const json = await response.json();
 
-      // Filter meetups so they are only from democracy campaign
-      let filteredMeetups;
-      if (!isBerlin) {
-        filteredMeetups = json.data.filter(
+        // Filter meetups so they are only from democracy campaign
+        const filteredMeetups = json.data.filter(
           ({ campaign }) => campaign?.state === state
         );
-      } else {
-        filteredMeetups = json;
-      }
 
-      setMeetups(formatMeetups(isBerlin, filteredMeetups));
-    } else {
-      console.log('Response is not 200', response.status);
+        // IsListLocation does not matter for non berlin meetups
+        setMeetups(formatMeetups(false, false, filteredMeetups));
+      } else {
+        console.log('Response is not 200', response.status);
+      }
     }
   } catch (error) {
     console.log('Error while getting meetups', error);
   }
 };
 
-const getMeetupsFromAppApi = () => {
+const getEventsFromAppApi = () => {
   // Endpoint is POST to optionally receive  a filter as body
   const request = {
     method: 'POST',
@@ -54,10 +80,26 @@ const getMeetupsFromAppApi = () => {
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({}),
+    // Pass filter with attribute details to also fetch description
+    body: JSON.stringify({ details: true }),
   };
 
   return fetch(`${CONFIG.APP_API.INVOKE_URL}/service/termine`, request);
+};
+
+const getListLocationsFromAppApi = () => {
+  const request = {
+    method: 'GET',
+    mode: 'cors',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  };
+
+  return fetch(
+    `${CONFIG.APP_API.INVOKE_URL}/service/listlocations/actives`,
+    request
+  );
 };
 
 const getMeetupsFromWebsiteApi = () => {
@@ -69,42 +111,53 @@ const getMeetupsFromWebsiteApi = () => {
   return fetch(`${CONFIG.API.INVOKE_URL}/meetups`, request);
 };
 
-const formatMeetups = (isBerlin, meetups) => {
+const formatMeetups = (isBerlin, isListLocation, meetups) => {
   // We want to bring the meetups from the backend into the same format as
   // the ones from contentful
   if (isBerlin) {
-    // Using reduce to filter and map ad same time
-    return meetups.reduce(
-      (
-        filteredArray,
-        { beginn, ende, latitude, longitude, ort, details, typ }
-      ) => {
-        // Filter out collection meetups of the past
-        if (
-          (typ === 'Sammeln' && new Date(beginn) > new Date()) ||
-          typ === 'Listen ausgelegt'
-        ) {
-          filteredArray.push({
-            location: {
-              lon: longitude,
-              lat: latitude,
-            },
-            description: details?.beschreibung,
-            contact: details?.kontakt,
-            title: typ === 'Sammeln' ? 'Sammelaktion' : 'Unterschreiben',
-            // Meetup has time saved in db even though it is not really needed,
-            // which is why we strip it here
-            startTime: typ === 'Sammeln' ? beginn : null,
-            endTime: typ === 'Sammeln' ? ende : null,
-            locationName: ort,
-            address: details?.treffpunkt,
-            type: typ === 'Sammeln' ? 'collect' : 'lists',
-          });
-        }
-        return filteredArray;
-      },
-      []
-    );
+    if (!isListLocation) {
+      // Using reduce to filter and map ad same time
+      return meetups.reduce(
+        (
+          filteredArray,
+          { beginn, ende, latitude, longitude, ort, details, typ }
+        ) => {
+          // Filter out events of the past
+          if (new Date(beginn) > new Date()) {
+            filteredArray.push({
+              location: {
+                lon: longitude,
+                lat: latitude,
+              },
+              description: details?.beschreibung,
+              contact: details?.kontakt,
+              title: typ === 'Sammeln' ? 'Sammelaktion' : typ,
+              startTime: beginn,
+              endTime: ende,
+              locationName: ort,
+              address: details?.treffpunkt,
+              // TODO: maybe diversify in the future to account for other events
+              type: 'collect',
+            });
+          }
+          return filteredArray;
+        },
+        []
+      );
+    } else {
+      // List locations
+      return meetups.map(location => ({
+        ...location,
+        location: { lon: location.longitude, lat: location.latitude },
+        locationName: location.name,
+        type: 'lists',
+        address:
+          location.street && location.number
+            ? `${location.street} ${location.number}`
+            : null,
+        title: 'Listen ausgelegt',
+      }));
+    }
   } else {
     return meetups.map(
       ({ coordinates, description, type, locationName, ...rest }) => ({

--- a/src/pages/playground/karte.js
+++ b/src/pages/playground/karte.js
@@ -19,7 +19,7 @@ const PlaygroundMap = () => {
           <SectionInner wide={true}>
             <ShowMeetups
               mapConfig={{
-                state: 'democracy',
+                state: 'berlin',
                 config: {
                   maxBounds: [
                     [13.05, 52.2],


### PR DESCRIPTION
I haven't come around to setting up a dev server yet, but we'll just use the prod backend until then. We'll just clean up all the data before the launch. You can go to /playground/karte and test creating an event and a list location. 