### PR TITLE
Prepäre pledge packages for berlin

### DIFF
--- a/src/components/PledgePackage/CreatePledgePackage/index.js
+++ b/src/components/PledgePackage/CreatePledgePackage/index.js
@@ -17,7 +17,7 @@ export default ({ userData, updateCustomUserData }) => {
   const [pledgePackageState, uploadPledgePackage] = useSaveInteraction();
   const [, setPledgePackage] = useState();
   const [, updateUser] = useUpdateUser();
-  const [campaignCode, setCampaignCode] = useState('bremen-1');
+  const [campaignCode, setCampaignCode] = useState('berlin-2');
 
   useEffect(() => {
     const urlParams = querystring.parse(window.location.search);
@@ -179,7 +179,7 @@ export default ({ userData, updateCustomUserData }) => {
                 </div>
                 <div className={s.descriptionTextElement}>
                   <p>
-                    Mit dem Sammelpaket versprichst du, 50 Unterschriften
+                    Mit dem Sammelpaket versprichst du, 25 Unterschriften
                     einzusammeln. Das ist super!
                     <br />
                     <br />

--- a/src/components/PledgePackage/ListPledgePackages/PledgePackageSection.js
+++ b/src/components/PledgePackage/ListPledgePackages/PledgePackageSection.js
@@ -61,7 +61,7 @@ export const PledgePackagesSection = () => {
             ) : (
               <p>
                 Du hast dir {packagesOfUser.length} Pakete geschnappt und somit
-                versprochen, {packagesOfUser.length * 50} Unterschriften zu
+                versprochen, {packagesOfUser.length * 25} Unterschriften zu
                 sammeln.
               </p>
             )}

--- a/src/components/PledgePackage/ListPledgePackages/index.js
+++ b/src/components/PledgePackage/ListPledgePackages/index.js
@@ -12,7 +12,7 @@ import { Package } from './Package';
 export default () => {
   const [state, pledgePackages, getInteractions] =
     useGetMostRecentInteractions();
-  const { userId, customUserData: userData } = useContext(AuthContext);
+  const { customUserData: userData } = useContext(AuthContext);
   const [packagesOfUser, setPackagesOfUser] = useState([]);
   const [pledgePackagesDone, setPledgePackagesDone] = useState([]);
 
@@ -43,7 +43,7 @@ export default () => {
       <h2 className={s.violet}>Alle Sammelpakete</h2>
       <p>
         Zeig deinen Einsatz für's Grundeinkommen und setze dir ein Sammelziel!
-        Es gibt Pakete mit jeweils einem Ziel von 50 Unterschriften, von denen
+        Es gibt Pakete mit jeweils einem Ziel von 25 Unterschriften, von denen
         du dir so viele nehmen kannst, wie du möchtest!{' '}
         {userData.interactions &&
           packagesOfUser.length === 0 &&
@@ -70,7 +70,7 @@ export default () => {
           <h3 className={s.violet}>Deine Pakete</h3>
           <p>
             Du hast dir {packagesOfUser.length} Pakete geschnappt und somit
-            versprochen, {packagesOfUser.length * 50} Unterschriften zu sammeln.
+            versprochen, {packagesOfUser.length * 25} Unterschriften zu sammeln.
           </p>
           <div className={s.container}>
             {packagesOfUser.map((pledgePackage, index) => {
@@ -91,13 +91,11 @@ export default () => {
       )}
 
       <div className={s.CTA}>
-        {userId && (
-          <CTALink to={`/mensch/${userId}/paket-nehmen`}>
-            {userData && packagesOfUser.length === 0
-              ? 'Nimm dein Paket'
-              : 'Weiteres Paket nehmen'}
-          </CTALink>
-        )}
+        <CTALink to={`/me/paket-nehmen`}>
+          {userData && packagesOfUser.length === 0
+            ? 'Nimm dein Paket'
+            : 'Weiteres Paket nehmen'}
+        </CTALink>
       </div>
 
       {state && state !== 'loading' ? (

--- a/src/components/Profile/ProfileOverview/index.js
+++ b/src/components/Profile/ProfileOverview/index.js
@@ -31,6 +31,8 @@ export const ProfileOverview = ({ userData, signatureCountOfUser }) => {
   //     ({ ags }) => ags === stateToAgs['bremen']
   //   ) !== -1;
 
+  const showPackageSection = IS_BERLIN_PROJECT || isSignedUpForBerlin;
+
   // Filter interactions to only use interactions which were created
   // as pledge package
   useEffect(() => {
@@ -142,14 +144,12 @@ export const ProfileOverview = ({ userData, signatureCountOfUser }) => {
         </section>
       </Link>
 
-      {/* Only show this section if user is signed up for berlin */}
-      {(IS_BERLIN_PROJECT || isSignedUpForBerlin) && (
+      {/* Only show this section if user is signed up for berlin or if berlin page */}
+      {showPackageSection && (
         <Link
           to="paket-nehmen"
-          className={cN(s.profilePageSection, {
-            [s.profilePageSectionLarge]: !(
-              IS_BERLIN_PROJECT || isSignedUpForBerlin
-            ),
+          className={cN(s.profilePageSection, s.profilePageSectionLarge, {
+            [s.rose]: IS_BERLIN_PROJECT,
           })}
         >
           <section>

--- a/src/components/Profile/ProfileOverview/index.js
+++ b/src/components/Profile/ProfileOverview/index.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import AvatarImage from '../../AvatarImage';
 import SignatureStats from '../../SignatureStats';
-import { formatDate /*stateToAgs*/ } from '../../utils';
+import { formatDate, stateToAgs } from '../../utils';
 import * as s from './style.module.less';
 import * as gS from '../style.module.less';
 import cN from 'classnames';
@@ -11,7 +11,7 @@ import { getCustomNewsletterEnumeration } from '../utils/customNewsletterEnumera
 const IS_BERLIN_PROJECT = process.env.GATSBY_PROJECT === 'Berlin';
 
 export const ProfileOverview = ({ userData, signatureCountOfUser }) => {
-  const [, setPledgePackages] = useState([]);
+  const [pledgePackages, setPledgePackages] = useState([]);
 
   // list newsletters of current user as human readable string
   const customNewsletterEnumeration = getCustomNewsletterEnumeration({
@@ -21,10 +21,10 @@ export const ProfileOverview = ({ userData, signatureCountOfUser }) => {
   const referredUserMessage = getReferredUserMessage({ userData });
 
   // NOTE: not needed for now, reactivate as soon as pledge packages are used for berlin
-  // const isSignedUpForBerlin =
-  //   userData.municipalities?.findIndex(
-  //     ({ ags }) => ags === stateToAgs['berlin']
-  //   ) !== -1;
+  const isSignedUpForBerlin =
+    userData.municipalities?.findIndex(
+      ({ ags }) => ags === stateToAgs['berlin']
+    ) !== -1;
 
   // const isSignedUpForBremen =
   //   userData.municipalities?.findIndex(
@@ -142,6 +142,50 @@ export const ProfileOverview = ({ userData, signatureCountOfUser }) => {
         </section>
       </Link>
 
+      {/* Only show this section if user is signed up for berlin */}
+      {(IS_BERLIN_PROJECT || isSignedUpForBerlin) && (
+        <Link
+          to="paket-nehmen"
+          className={cN(s.profilePageSection, {
+            [s.profilePageSectionLarge]: !(
+              IS_BERLIN_PROJECT || isSignedUpForBerlin
+            ),
+          })}
+        >
+          <section>
+            <h2>Dein Sammelpaket</h2>
+            <p>
+              {pledgePackages.length ? (
+                <>
+                  Du hast dir {pledgePackages.length} Paket
+                  {pledgePackages.length > 1 && 'e'} geschnappt und somit
+                  versprochen, 50 Unterschriften zu sammeln.
+                  <br />
+                  <br />
+                  {/* TODO: design package */}
+                  {/* Find package with message if exists to show this package (maybe in the future
+                    show most recent (was kinda in a hurry) */}
+                  "
+                  {
+                    pledgePackages.find(pledgePackage => pledgePackage.body)
+                      ?.body
+                  }
+                  "
+                </>
+              ) : (
+                <>Du hast noch kein Sammelpaket genommen.</>
+              )}
+            </p>
+            <div className={s.sectionLink}>
+              <span>
+                {pledgePackages.length
+                  ? 'Weiteres Paket nehmen'
+                  : 'Nimm dein Paket'}
+              </span>
+            </div>
+          </section>
+        </Link>
+      )}
       {/* {signatureCountOfUser && (
         <a className={cN(s.profilePageSection, s.profilePageSectionLarge)}
           href={`/${signatureCountOfUser.mostRecentCampaign

--- a/src/hooks/Api/Interactions/index.js
+++ b/src/hooks/Api/Interactions/index.js
@@ -80,8 +80,12 @@ const getMostRecentInteractions = async (
       mode: 'cors',
     };
 
+    // TODO: change campaign code or pass it from somewhere if there are mor campaigns
+    // simultaneously
     const response = await fetch(
-      `${CONFIG.API.INVOKE_URL}/interactions?limit=${limit}${
+      `${
+        CONFIG.API.INVOKE_URL
+      }/interactions?limit=${limit}&campaignCode=berlin-2${
         userId ? `&userId=${userId}` : ''
       }${type ? `&type=${type}` : ''}`,
       request


### PR DESCRIPTION
1) Only show packages for berlin-2
2) Always show button in hall of fame to navigate to /paket-nehmen (even if logged out)
3) Show section in profile for berlin page or if user is signed up for berlin

In contrast to earlier, the sections for "Unterschriften eintragen" and "Paket nehmen" are now full width due to the heading of the new font being bigger. 