### PR TITLE
Collector signup newsletter

### DIFF
--- a/src/components/Forms/SignUp/index.js
+++ b/src/components/Forms/SignUp/index.js
@@ -104,9 +104,10 @@ export default ({
       userExists !== false
     ) {
       updateUser({
-        ...formData,
-        updatedOnXbge: true,
+        // TODO: check if we need to add ags here at all
         ags: municipalityInForm?.ags,
+        updatedOnXbge: true,
+        ...formData,
       });
       setSignUpState('signedIn');
     }

--- a/src/pages/sammeln/aktiv-werden/index.js
+++ b/src/pages/sammeln/aktiv-werden/index.js
@@ -7,7 +7,7 @@ import {
 } from '../../../components/Layout/Sections';
 import * as s from './style.module.less';
 import AvatarImage from '../../../components/AvatarImage';
-import { CTALink } from '../../../components/Layout/CTAButton';
+import { CTALink, CTALinkExternal } from '../../../components/Layout/CTAButton';
 import AuthContext from '../../../context/Authentication';
 
 const CollectorNextStepsPage = () => {
@@ -28,15 +28,23 @@ const CollectorNextStepsPage = () => {
                   Hallo {customUserData?.username}! <br />
                   Danke, dass du mitsammelst. Wir melden uns bei dir, wenn wir
                   eine Aktion planen. Bitte hilf uns, indem du selbst aktiv
-                  wirst, dich mit anderen vernetzt und Sammelevents planst!
-                  Folgendes kannst du jetzt tun:
+                  wirst, dich mit anderen vernetzt und Sammelevents planst! Wenn
+                  du mitsammeln oder selbst ein Event planen willst, kannst du
+                  das über einen dieser Wege:
                 </p>
 
-                <h3>Mitsammeln oder ein Event planen</h3>
-                <CTALink to="/aktiv-werden">Aktiv werden</CTALink>
+                <h3>Über die Website</h3>
+                <CTALink to="/berlin/termine#karte">Zur Sammelkarte</CTALink>
 
-                <h3>Dich mit anderen in deinem Kiez vernetzen</h3>
-                <CTALink to="/aktiv-werden">Vernetze dich</CTALink>
+                <h3>Über die Sammelapp</h3>
+                <CTALinkExternal href="https://play.google.com/store/apps/details?id=berlin.sammelapp">
+                  Zur Android App
+                </CTALinkExternal>
+                <br />
+                <br />
+                <CTALinkExternal href="https://apps.apple.com/us/app/berliner-sammel-app/id1619980654">
+                  Zur iOS App
+                </CTALinkExternal>
               </div>
             </div>
           </SectionInner>

--- a/src/pages/sammeln/anmelden/index.js
+++ b/src/pages/sammeln/anmelden/index.js
@@ -8,7 +8,7 @@ import {
 } from '../../../components/Layout/Sections';
 import * as s from './style.module.less';
 import querystring from 'query-string';
-import { formatDate } from '../../../components/utils';
+import { formatDate, stateToAgs } from '../../../components/utils';
 import { navigate } from 'gatsby';
 
 const CollectorSignUpPage = () => {
@@ -58,6 +58,10 @@ const CollectorSignUpPage = () => {
                     date && location
                       ? { meetup: { date, location } }
                       : { inGeneral: true },
+                  newsletterConsent: true,
+                  extraInfo: true,
+                  // TODO: handle different states
+                  ags: stateToAgs.berlin,
                 }}
                 postSignupAction={() => navigate('/sammeln/bild-hochladen')}
                 showHeading={false}

--- a/src/pages/sammeln/bild-hochladen/index.js
+++ b/src/pages/sammeln/bild-hochladen/index.js
@@ -28,7 +28,7 @@ const CollectorImageUploadPage = () => {
   // If not authenticated we want to navigate to anmeldung page
   useEffect(() => {
     if (isAuthenticated === false) {
-      navigate('/sammeln/anmeldung');
+      navigate('/sammeln/anmelden');
     }
   }, [isAuthenticated]);
 


### PR DESCRIPTION
I now added in the backend (https://github.com/grundeinkommensbuero/backend/commit/fb7f40c256289993a911ccbcd1cf08d7f2178ab2) that you can add the extraInfo flag, so people are added to the "Aktivenverteiler". 

In the frontend on the signup page for collectors, the user is now being signed up for municipality (only berlin for now), general newsletter, berlin newsletter and berlin "Aktivenverteiler". 