### PR TITLE
Render /berlin/* as /*

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -157,7 +157,7 @@ exports.createPages = ({ graphql, actions }) => {
               path = '/';
             } else if (page.node.slug.includes('berlin')) {
               path = path.replace('berlin/', '');
-              slug = slug.replace('berlin/', '');
+              // slug = slug.replace('berlin/', '');
             } else if (
               page.node.slug !== 'impressum' &&
               page.node.slug !== 'datenschutz'

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -146,28 +146,34 @@ exports.createPages = ({ graphql, actions }) => {
 
         const pages = result.data.allContentfulStaticContent.edges;
         pages.forEach(page => {
+          const isMunicipality = page.node.slug === 'orte';
+
           let path = page.node.slug === '/' ? '/' : `/${page.node.slug}/`;
-          let slug = page.node.slug;
 
           if (process.env.GATSBY_PROJECT === 'Berlin') {
             if (page.node.slug === 'berlin') {
               // We want to deploy the /berlin page to root /
               path = '/';
             } else if (page.node.slug.includes('berlin')) {
-              path = path.replace('berlin/', '');
-              slug = slug.replace('berlin/', '');
-            } else {
-              // Don't render any page that is not /berlin/*
+              // So the navigation does not break locally due to missing redirects,
+              // we don't override the path locally
+              if (process.env.NODE_ENV !== 'development') {
+                path = page.node.slug.replace('berlin/', '');
+              }
+            } else if (
+              page.node.slug !== 'impressum' &&
+              page.node.slug !== 'datenschutz'
+            ) {
+              // Don't render any page that is not /berlin/* or impressum or datenschutz
               return;
             }
           }
 
-          const isMunicipality = page.node.slug === 'orte';
           createPage({
             path,
             component: staticPage,
             context: {
-              slug,
+              slug: page.node.slug,
               isMunicipality,
               isSpecificMunicipality: false,
             },

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -147,21 +147,27 @@ exports.createPages = ({ graphql, actions }) => {
         const pages = result.data.allContentfulStaticContent.edges;
         pages.forEach(page => {
           let path = page.node.slug === '/' ? '/' : `/${page.node.slug}/`;
+          let slug = page.node.slug;
 
           if (process.env.GATSBY_PROJECT === 'Berlin') {
-            if (page.node.slug === '/') {
-              return;
-            } else if (page.node.slug === 'berlin') {
+            if (page.node.slug === 'berlin') {
               // We want to deploy the /berlin page to root /
               path = '/';
+            } else if (page.node.slug.includes('berlin')) {
+              path = path.replace('berlin/', '');
+              slug = slug.replace('berlin/', '');
+            } else {
+              // Don't render any page that is not /berlin/*
+              return;
             }
           }
+
           const isMunicipality = page.node.slug === 'orte';
           createPage({
-            path: path,
+            path,
             component: staticPage,
             context: {
-              slug: page.node.slug,
+              slug,
               isMunicipality,
               isSpecificMunicipality: false,
             },

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -149,6 +149,7 @@ exports.createPages = ({ graphql, actions }) => {
           const isMunicipality = page.node.slug === 'orte';
 
           let path = page.node.slug === '/' ? '/' : `/${page.node.slug}/`;
+          let slug = page.node.slug;
 
           if (process.env.GATSBY_PROJECT === 'Berlin') {
             if (page.node.slug === 'berlin') {
@@ -158,7 +159,8 @@ exports.createPages = ({ graphql, actions }) => {
               // So the navigation does not break locally due to missing redirects,
               // we don't override the path locally
               if (process.env.NODE_ENV !== 'development') {
-                path = page.node.slug.replace('berlin/', '');
+                path = path.replace('berlin/', '');
+                slug = slug.replace('berlin/', '');
               }
             } else if (
               page.node.slug !== 'impressum' &&
@@ -173,7 +175,7 @@ exports.createPages = ({ graphql, actions }) => {
             path,
             component: staticPage,
             context: {
-              slug: page.node.slug,
+              slug,
               isMunicipality,
               isSpecificMunicipality: false,
             },

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -156,12 +156,8 @@ exports.createPages = ({ graphql, actions }) => {
               // We want to deploy the /berlin page to root /
               path = '/';
             } else if (page.node.slug.includes('berlin')) {
-              // So the navigation does not break locally due to missing redirects,
-              // we don't override the path locally
-              if (process.env.NODE_ENV !== 'development') {
-                path = path.replace('berlin/', '');
-                slug = slug.replace('berlin/', '');
-              }
+              path = path.replace('berlin/', '');
+              slug = slug.replace('berlin/', '');
             } else if (
               page.node.slug !== 'impressum' &&
               page.node.slug !== 'datenschutz'

--- a/src/components/Layout/Footer/index.js
+++ b/src/components/Layout/Footer/index.js
@@ -15,7 +15,10 @@ export default ({ footerText, footerMenu }) => (
         <ul className={s.nav}>
           {footerMenu.map((item, index) => (
             <li className={s.navItem} key={index}>
-              <Link to={`/${item.slug}/`} className={s.link}>
+              <Link
+                to={`/${item.slug.replace('berlin/', '')}/`}
+                className={s.link}
+              >
                 {item.title}
               </Link>
             </li>

--- a/src/components/Layout/Header/Menu/MenuItem.jsx
+++ b/src/components/Layout/Header/Menu/MenuItem.jsx
@@ -9,7 +9,7 @@ const MenuItemLink = ({ slug, isChild, children, className, ...rest }) => (
     <Link
       className={cN(s.link, className)}
       activeClassName={s.linkActive}
-      to={slug === '/' ? '/' : `/${slug}/`}
+      to={slug === '/' ? '/' : `/${slug.replace('/berlin', '')}/`}
       {...rest}
     >
       {children}

--- a/src/components/Layout/Header/Menu/MenuItem.jsx
+++ b/src/components/Layout/Header/Menu/MenuItem.jsx
@@ -9,7 +9,7 @@ const MenuItemLink = ({ slug, isChild, children, className, ...rest }) => (
     <Link
       className={cN(s.link, className)}
       activeClassName={s.linkActive}
-      to={slug === '/' ? '/' : `/${slug.replace('/berlin', '')}/`}
+      to={slug === '/' ? '/' : `/${slug.replace('berlin/', '')}/`}
       {...rest}
     >
       {children}

--- a/static/_redirects
+++ b/static/_redirects
@@ -13,3 +13,4 @@ https://expedition-grundeinkommen.de/gemeinde-teilen/*  https://ag5gu1z06h.execu
 /bremen                                         /orte/bremen
 /gemeinden/*                                    /orte/:splat
 /teilen/:userId                                 /teilen/?userId=:userId
+/berlin/*                                       /:splat


### PR DESCRIPTION
Okay, got it to work. Had to...
1) Override all /berlin/* paths to /* in gatsby-node, but leave the slugs as is 
2) Override the paths in the menu and footer. This would not have been necessary, as we also could have changed the paths in contentful, but this makes testing and merging the pr easier. 

I also added a redirect from /berlin/* to /*, so the links that are already out there still work