### PR TITLE
MenuOberpunkt as child in menu

### DIFF
--- a/src/components/Layout/Header/Menu/MenuItem.jsx
+++ b/src/components/Layout/Header/Menu/MenuItem.jsx
@@ -4,16 +4,35 @@ import cN from 'classnames';
 
 import * as s from './style.module.less';
 
-const MenuItemLink = ({ slug, isChild, children, className, ...rest }) => (
+const MenuItemLink = ({
+  slug,
+  isChild,
+  children,
+  className,
+  externalLink,
+  ...rest
+}) => (
   <li className={cN(s.navItem, { [s.navItemChild]: isChild })}>
-    <Link
-      className={cN(s.link, className)}
-      activeClassName={s.linkActive}
-      to={slug === '/' ? '/' : `/${slug.replace('berlin/', '')}/`}
-      {...rest}
-    >
-      {children}
-    </Link>
+    {externalLink && (
+      <a
+        className={s.link}
+        href={externalLink}
+        rel="noreferrer"
+        target="_blank"
+      >
+        {children}
+      </a>
+    )}
+    {slug && (
+      <Link
+        className={cN(s.link, className)}
+        activeClassName={s.linkActive}
+        to={slug === '/' ? '/' : `/${slug.replace('berlin/', '')}/`}
+        {...rest}
+      >
+        {children}
+      </Link>
+    )}
   </li>
 );
 

--- a/src/components/Layout/Header/Menu/index.jsx
+++ b/src/components/Layout/Header/Menu/index.jsx
@@ -42,7 +42,7 @@ const Menu = ({ menu, menuOpen }) => {
                     key={index}
                     isChild={true}
                     // Replace /, so internal links work with or without /
-                    slug={item.slug || item.internalLink.replace('/', '')}
+                    slug={item.slug || item.internalLink?.replace('/', '')}
                     externalLink={item.externalLink}
                   >
                     {item.shortTitle || item.title}

--- a/src/components/Layout/Header/Menu/index.jsx
+++ b/src/components/Layout/Header/Menu/index.jsx
@@ -38,7 +38,13 @@ const Menu = ({ menu, menuOpen }) => {
               {/* Map thru children of the menu item and pass to the submenu */}
               {item.contentfulchildren &&
                 item.contentfulchildren.map((item, index) => (
-                  <MenuItemLink key={index} isChild={true} slug={item.slug}>
+                  <MenuItemLink
+                    key={index}
+                    isChild={true}
+                    // Replace /, so internal links work with or without /
+                    slug={item.slug || item.internalLink.replace('/', '')}
+                    externalLink={item.externalLink}
+                  >
                     {item.shortTitle || item.title}
                   </MenuItemLink>
                 ))}

--- a/src/components/Layout/index.js
+++ b/src/components/Layout/index.js
@@ -52,9 +52,18 @@ function Template({ children, sections, pageContext, title, description }) {
                 internalLink
                 externalLink
                 contentfulchildren {
-                  title
-                  slug
-                  shortTitle
+                  ... on ContentfulStaticContent {
+                    __typename
+                    slug
+                    title
+                    shortTitle
+                  }
+                  ... on ContentfulMenuOberpunkt {
+                    __typename
+                    title
+                    internalLink
+                    externalLink
+                  }
                 }
               }
             }


### PR DESCRIPTION
Resolves: https://expedition-grundeinkommen.monday.com/boards/853311751/pulses/2629930227

It was already possible the add a MenuOberPunkt as child of a OberPunkt, but the code did not offer it (anymore?). 
I already added Draft entries in Contentful. To test, you can publish them, but it will break the build of master.  