### PR TITLE
Vertical centering for thirds components

### DIFF
--- a/src/components/Layout/Sections/style.module.less
+++ b/src/components/Layout/Sections/style.module.less
@@ -655,6 +655,7 @@
 .componentLeftThird {
   grid-column-start: 1;
   grid-column-end: last-line;
+  align-self: center;
 
   @media (min-width: @breakPointL) {
     padding-right: 2.5rem;
@@ -667,6 +668,8 @@
 .componentRightThird {
   grid-column-start: 1;
   grid-column-end: last-line;
+  align-self: center;
+
   @media (min-width: @breakPointL) {
     padding-left: 2.5rem;
     grid-column-start: 5;
@@ -677,6 +680,8 @@
 .componentCenterThird {
   grid-column-start: 1;
   grid-column-end: last-line;
+  align-self: center;
+
   @media (min-width: @breakPointL) {
     padding-left: 2.5rem;
     padding-right: 2.5rem;


### PR DESCRIPTION
Just a quick fix to make the partner logos look better.