### PR TITLE
Pledge: show snackbar with link to self scan

### DIFF
--- a/src/components/PledgePackage/ListPledgePackages/Package.js
+++ b/src/components/PledgePackage/ListPledgePackages/Package.js
@@ -10,6 +10,8 @@ import {
 import paketSvg from '../paket-v2.svg';
 import check from '../check.svg';
 import { LoadingAnimation } from '../../LoadingAnimation';
+import { SnackbarMessageContext } from '../../../context/Snackbar';
+import { Link } from 'gatsby';
 
 export const Package = ({
   body,
@@ -23,9 +25,21 @@ export const Package = ({
   const [pledgeUpdateState, updatePledgePackage] = useUpdateInteraction();
   const { updateCustomUserData } = useContext(AuthContext);
   const [, , getInteractions] = useGetMostRecentInteractions();
+  const { setMessage, setDuration } = useContext(SnackbarMessageContext);
 
   useEffect(() => {
     if (pledgeUpdateState === 'saved') {
+      // We want the snackbar to show longer in this case
+      setDuration(12000);
+      setMessage(
+        <p>
+          Super!{' '}
+          <Link to="/me/unterschriften-eintragen">
+            Trag hier deine Unterschriften ein
+          </Link>{' '}
+          und lass den Balken steigen.
+        </p>
+      );
       getInteractions(null, 0, 'pledgePackage');
       updateCustomUserData();
     }

--- a/src/context/Snackbar/index.js
+++ b/src/context/Snackbar/index.js
@@ -10,16 +10,19 @@ export const SnackbarMessageContext = React.createContext({
 export const SnackbarMessageProvider = ({ children }) => {
   const [openSnackbar] = useSnackbar(snackbarTheme);
   const [message, setMessage] = useState('');
+  const [duration, setDuration] = useState(6000);
 
   useEffect(() => {
     if (message !== '') {
-      openSnackbar(message, [6000]);
+      openSnackbar(message, [duration]);
       setMessage('');
     }
   }, [message]);
 
   return (
-    <SnackbarMessageContext.Provider value={{ message, setMessage }}>
+    <SnackbarMessageContext.Provider
+      value={{ message, setMessage, setDuration }}
+    >
       {children}
     </SnackbarMessageContext.Provider>
   );


### PR DESCRIPTION
Resolves: https://expedition-grundeinkommen.monday.com/boards/853311751/pulses/2653576246

This is my proposal to link the pledge package feature with our register signatures feature in the profile page. 
I first  experimented with displaying a link near the package. But it looked weird. The snackbar is probably better imo. 