### PR TITLE
Events list in one column and added contact

### DIFF
--- a/src/components/Maps/EventsListed.js
+++ b/src/components/Maps/EventsListed.js
@@ -57,7 +57,11 @@ export const EventsListed = ({ locationsFiltered }) => {
                   {groupedEvents[key].map((event, index) => {
                     return (
                       <div key={index} className={s.eventDescription}>
-                        <p className={s.descriptionText}>{event.description}</p>
+                        <div className={s.descriptionText}>
+                          <p>{event.description}</p>
+                          <p>Kontakt: {event.contact}</p>
+                        </div>
+
                         <p>
                           <b>
                             {dsm.localeTime(event.startTime)}-

--- a/src/components/Maps/style.module.less
+++ b/src/components/Maps/style.module.less
@@ -199,19 +199,11 @@
 
 .eventContainer {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
 }
 
 .eventDay {
-  flex: 50%;
-  min-width: 50%;
-  max-width: 50%;
-
-  @media (max-width: @breakPointL) {
-    flex: 100%;
-    min-width: 100%;
-    max-width: 100%;
-  }
+  width: 100%;
 }
 
 .moduleHeading {
@@ -238,7 +230,6 @@
 .eventDescription {
   margin-top: 1rem;
   margin-bottom: 3rem;
-  padding-right: 1rem;
   font-size: 1.5rem;
 
   @media (max-width: @breakPointM) {


### PR DESCRIPTION
Team members found the layout to be confusing and asked me to change it if possible (ideally just one column). It's now a wide column. I also tried a narrow centered column, but it looked kinda weird in context. 

We could also have the events of one day change between left and right column, but then we would still have the issue of white spaces. 

I also added the contact, which was missing. 