### PR TITLE
Set team member as default participant

### DIFF
--- a/src/hooks/Api/Meetups/Create/index.js
+++ b/src/hooks/Api/Meetups/Create/index.js
@@ -42,6 +42,8 @@ const createMeetup = async (userId, data, isBerlin, setState) => {
             longitude: data.coordinates[0],
             latitude: data.coordinates[1],
             initiativenIds: [1], // 1 is Expedition
+            // Set xbge team member as default participant
+            participants: [{ id: 112 }],
             details: {
               beschreibung: data.description,
               kontakt: data.contact,


### PR DESCRIPTION
It's not really possible to set a team member as the owner when creating an event via the website. So I am setting our team member (id 112) as a participant as default. 

I need to delete the test event as soon as you create one. Because it is written into the live db. So let me know :) 