### PR TITLE
Berlin spacing fixes

### DIFF
--- a/src/components/Layout/Sections/style.module.less
+++ b/src/components/Layout/Sections/style.module.less
@@ -652,13 +652,19 @@
   }
 }
 
+.componentLeftThird,
+.componentRightThird,
+.componentCenterThird {
+  align-self: center;
+  padding: 2rem 0;
+}
+
 .componentLeftThird {
   grid-column-start: 1;
   grid-column-end: last-line;
-  align-self: center;
 
   @media (min-width: @breakPointL) {
-    padding-right: 2.5rem;
+    padding: 0 2.5rem 0 0;
     grid-column-start: 1;
     grid-column-end: 3;
     margin-bottom: 0;
@@ -668,10 +674,9 @@
 .componentRightThird {
   grid-column-start: 1;
   grid-column-end: last-line;
-  align-self: center;
 
   @media (min-width: @breakPointL) {
-    padding-left: 2.5rem;
+    padding: 0 0 0 2.5rem;
     grid-column-start: 5;
     grid-column-end: last-line;
   }
@@ -680,11 +685,9 @@
 .componentCenterThird {
   grid-column-start: 1;
   grid-column-end: last-line;
-  align-self: center;
 
   @media (min-width: @breakPointL) {
-    padding-left: 2.5rem;
-    padding-right: 2.5rem;
+    padding: 0 2.5rem;
     grid-column-start: 3;
     grid-column-end: 5;
   }

--- a/src/components/style/baseBerlin.less
+++ b/src/components/style/baseBerlin.less
@@ -24,7 +24,7 @@
     box-shadow: none;
     text-decoration: underline;
     text-decoration-thickness: 0.15em;
-    text-underline-offset: 0.15em;
+    text-underline-offset: 0.18em;
 
     &:hover {
       text-decoration: none;

--- a/src/components/style/baseBerlin.less
+++ b/src/components/style/baseBerlin.less
@@ -19,4 +19,15 @@
   p {
     line-height: 1.25;
   }
+
+  p a {
+    box-shadow: none;
+    text-decoration: underline;
+    text-decoration-thickness: 0.15em;
+    text-underline-offset: 0.15em;
+
+    &:hover {
+      text-decoration: none;
+    }
+  }
 }


### PR DESCRIPTION
Links looked bad on the Berlin page, and spacing was off for the partner logos. Please check if it looks good in all browsers and screen sizes. 