### PR TITLE
Meetups: pass default user to only fetch future events

### DIFF
--- a/backend-config.js
+++ b/backend-config.js
@@ -21,7 +21,7 @@ export default {
   APP_API: {
     INVOKE_URL:
       process.env.NODE_ENV === 'development'
-        ? 'http://localhost:18080'
+        ? 'https://app-server.xbge.de'
         : 'https://app-server.xbge.de',
   },
 };

--- a/backend-config.js
+++ b/backend-config.js
@@ -21,7 +21,7 @@ export default {
   APP_API: {
     INVOKE_URL:
       process.env.NODE_ENV === 'development'
-        ? 'https://app-server.xbge.de'
+        ? 'http://localhost:18080'
         : 'https://app-server.xbge.de',
   },
 };

--- a/src/hooks/Api/Meetups/Get/index.js
+++ b/src/hooks/Api/Meetups/Get/index.js
@@ -81,6 +81,10 @@ const getEventsFromAppApi = () => {
     mode: 'cors',
     headers: {
       'Content-Type': 'application/json',
+      // Pass auth for a default user to trigger filter on the server
+      // to only serve future events, maybe in the future we can handle
+      // it differently on the server
+      Authorization: `Basic ${process.env.GATSBY_APP_BACKEND_AUTH}`,
     },
     // Pass filter with attribute details to also fetch description
     body: JSON.stringify({ details: true }),
@@ -129,33 +133,24 @@ const formatMeetups = (isBerlin, meetups) => {
   // We want to bring the meetups from the backend into the same format as
   // the ones from contentful
   if (isBerlin) {
-    // Using reduce to filter and map ad same time
-    return meetups.reduce(
-      (
-        filteredArray,
-        { beginn, ende, latitude, longitude, ort, details, typ }
-      ) => {
-        // Filter out events of the past
-        if (new Date(ende) > new Date()) {
-          filteredArray.push({
-            location: {
-              lon: longitude,
-              lat: latitude,
-            },
-            description: details?.beschreibung,
-            contact: details?.kontakt,
-            title: typ === 'Sammeln' ? 'Sammelaktion' : typ,
-            startTime: beginn,
-            endTime: ende,
-            locationName: ort,
-            address: details?.treffpunkt,
-            // TODO: maybe diversify in the future to account for other events
-            type: 'collect',
-          });
-        }
-        return filteredArray;
-      },
-      []
+    // We used to filter out past events here, but since this is done on the server
+    // now, we don't need to do that anymore
+    return meetups.map(
+      ({ beginn, ende, latitude, longitude, ort, details, typ }) => ({
+        location: {
+          lon: longitude,
+          lat: latitude,
+        },
+        description: details?.beschreibung,
+        contact: details?.kontakt,
+        title: typ === 'Sammeln' ? 'Sammelaktion' : typ,
+        startTime: beginn,
+        endTime: ende,
+        locationName: ort,
+        address: details?.treffpunkt,
+        // TODO: maybe diversify in the future to account for other events
+        type: 'collect',
+      })
     );
   } else {
     return meetups.map(


### PR DESCRIPTION
Resolves not showing all future events. This is because I fetch all events and filter them out on the client (website). But there is a limit of 100 events being fetched. I could have adjusted the limit, but that's not really scalable. The server only returns future events if there is a user passed in the request (auth headers), I am not sure why. I also could have changed the server to alway return future events. But I wanted a quicker soluten, so I am now just passing a the auth headers of a default user.