### PR TITLE
Trigger update of campaign visualisation

### DIFF
--- a/src/components/CampaignVisualisations/index.js
+++ b/src/components/CampaignVisualisations/index.js
@@ -12,8 +12,14 @@ import VisualCounter from '../VisualCounter';
 import { useGetCrowdfundingDirectly } from '../../hooks/Api/Crowdfunding';
 import { contentfulJsonToHtml } from '../utils/contentfulJsonToHtml';
 
-export default ({ visualisations }) => {
-  const currentCounts = useSignatureCount();
+export default ({ visualisations, triggerUpdate }) => {
+  const [currentCounts, refetchCount] = useSignatureCount();
+
+  useEffect(() => {
+    if (triggerUpdate) {
+      refetchCount();
+    }
+  }, [triggerUpdate]);
 
   return (
     <>

--- a/src/components/Forms/SelfScan/CampaignScanVisualisation.js
+++ b/src/components/Forms/SelfScan/CampaignScanVisualisation.js
@@ -3,7 +3,7 @@ import { useStaticQuery, graphql } from 'gatsby';
 import CampaignVisualisations from '../../CampaignVisualisations';
 import * as s from './style.module.less';
 
-export const CampainScanVisualisation = ({ campaignCode }) => {
+export const CampainScanVisualisation = ({ campaignCode, triggerUpdate }) => {
   const {
     allContentfulKampagnenvisualisierung: { edges: campaignVisualisations },
   } = useStaticQuery(graphql`
@@ -40,6 +40,7 @@ export const CampainScanVisualisation = ({ campaignCode }) => {
         <div className={s.campaignVisualisations}>
           <CampaignVisualisations
             visualisations={campaignVisualisationsMapped}
+            triggerUpdate={triggerUpdate}
           />
         </div>
       )}

--- a/src/components/Forms/SelfScan/index.js
+++ b/src/components/Forms/SelfScan/index.js
@@ -18,7 +18,7 @@ import { TextInputWrapped } from '../TextInput';
 import * as s from './style.module.less';
 const IS_BERLIN_PROJECT = process.env.GATSBY_PROJECT === 'Berlin';
 
-export default ({ campaignCode, successMessage, className }) => {
+export default ({ campaignCode, successMessage, className, onUpdate }) => {
   const [state, updateSignatureList, resetSignatureListState] =
     useUpdateSignatureListByUser();
   const [signatureCountOfUser, getSignatureCountOfUser, resetSignatureCount] =
@@ -40,6 +40,10 @@ export default ({ campaignCode, successMessage, className }) => {
   useEffect(() => {
     if (userId || eMail) {
       getSignatureCountOfUser({ userId: userId, email: eMail, campaignCode });
+
+      if (state === 'saved' && onUpdate) {
+        onUpdate();
+      }
     }
   }, [userId, eMail, state]);
 

--- a/src/components/Profile/ProfileSignatures/index.js
+++ b/src/components/Profile/ProfileSignatures/index.js
@@ -17,6 +17,8 @@ export const ProfileSignatures = ({ userId, userData }) => {
     IS_BERLIN_PROJECT ? [campaignCodes[0]] : []
   );
 
+  const [updated, setUpdated] = useState(0);
+
   useEffect(() => {
     if (userData && 'municipalities' in userData && !IS_BERLIN_PROJECT) {
       const activeCampaigns = [];
@@ -58,6 +60,9 @@ export const ProfileSignatures = ({ userId, userData }) => {
                   ? userCampaigns[0].campaignCode
                   : null
               }
+              onUpdate={() => {
+                setUpdated(updated + 1);
+              }}
             />
             {userCampaigns[0] ? (
               userCampaigns.map((scan, index) => {
@@ -66,6 +71,7 @@ export const ProfileSignatures = ({ userId, userData }) => {
                     <h2>Eingegangene Unterschriften {scan.campaignName}</h2>
                     <CampainScanVisualisation
                       campaignCode={scan.campaignCode}
+                      triggerUpdate={updated}
                     />
                   </div>
                 );

--- a/src/hooks/Api/Signatures/Get/index.js
+++ b/src/hooks/Api/Signatures/Get/index.js
@@ -20,7 +20,7 @@ export const useSignatureCount = () => {
     }
   });
 
-  return stats;
+  return [stats, () => getSignatureCount().then(data => setStats(data))];
 };
 
 // Hook to get signature count of a user


### PR DESCRIPTION
Resolves: https://expedition-grundeinkommen.monday.com/boards/853311751/pulses/2893100716

I guess we just never implemented the signature count reloading after registering signatures. Not sure why. 
The way I did it is maybe not super sexy, but I just triggered the update via a state in the parent. 
We'll have to transfer this to the next project at some point. 